### PR TITLE
feat: implement edit profile page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,19 +1,26 @@
-import React, { type ComponentType } from "react";
 import type { Preview } from "@storybook/nextjs-vite";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import { type ComponentType } from "react";
 
-import { TRPCReactProviderStorybook } from "../src/trpc/msw";
+import { INITIAL_VIEWPORTS } from "storybook/viewport";
 import "../src/styles/globals.css";
+import { TRPCReactProviderStorybook } from "../src/trpc/msw";
 
 initialize({ quiet: true });
 
 const preview: Preview = {
+  initialGlobals: {
+    viewport: { value: "iphone13pro", isRotated: false },
+  },
   parameters: {
     controls: {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,
       },
+    },
+    viewport: {
+      options: INITIAL_VIEWPORTS,
     },
 
     msw: {

--- a/bun.lock
+++ b/bun.lock
@@ -6,11 +6,13 @@
       "name": "q-portal",
       "dependencies": {
         "@libsql/client": "^0.17.0",
+        "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@slack/web-api": "^7.13.0",
         "@t3-oss/env-nextjs": "^0.9.2",
         "@tanstack/react-query": "^5.90.19",
@@ -113,9 +115,9 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@better-auth/core": ["@better-auth/core@1.4.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg=="],
+    "@better-auth/core": ["@better-auth/core@1.4.19", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-uADLHG1jc5BnEJi7f6ijUN5DmPPRSj++7m/G19z3UqA3MVCo4Y4t1MMa4IIxLCqGDFv22drdfxescgW+HnIowA=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.4.18", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.18" } }, "sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.4.19", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.19" } }, "sha512-ApGNS7olCTtDpKF8Ow3Z+jvFAirOj7c4RyFUpu8axklh3mH57ndpfUAUjhgA8UVoaaH/mnm/Tl884BlqiewLyw=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
 
@@ -193,9 +195,9 @@
 
     "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.4", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.3", "strip-json-comments": "^3.1.1" } }, "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ=="],
 
-    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+    "@eslint/js": ["@eslint/js@9.39.3", "", {}, "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -209,7 +211,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.6.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.6.1" } }, "sha512-4Aji+soqukwUxq2DgHmkjxdGnG7hEiJuprqDlW4Wu6AQ0t8U9ItlICcM5to89pulIsEGrF1CkCoNrufQTcqb8A=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.7.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.7.0" } }, "sha512-JdsfSUVeWDP8klYL4y4C4Fae0nAv2V/2W+gHhdiuktyKGZvbSZfJpsk4loakPhTtxt91KHdDroXCCZcFIJrfYQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -298,8 +300,6 @@
     "@inquirer/select": ["@inquirer/select@2.5.0", "", { "dependencies": { "@inquirer/core": "^9.1.0", "@inquirer/figures": "^1.0.5", "@inquirer/type": "^1.5.3", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" } }, "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA=="],
 
     "@inquirer/type": ["@inquirer/type@1.5.5", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA=="],
-
-    "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
     "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
 
@@ -395,11 +395,13 @@
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
+    "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
+
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
-    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
 
     "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
 
@@ -419,7 +421,7 @@
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
 
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-progress": ["@radix-ui/react-progress@1.1.8", "", { "dependencies": { "@radix-ui/react-context": "1.1.3", "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA=="],
 
@@ -430,6 +432,8 @@
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
@@ -453,55 +457,55 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.57.1", "", { "os": "android", "cpu": "arm64" }, "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.57.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.57.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.57.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
 
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw=="],
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
 
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw=="],
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.57.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
 
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.57.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw=="],
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.57.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.57.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.57.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew=="],
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
 
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ=="],
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
     "@slack/logger": ["@slack/logger@4.0.0", "", { "dependencies": { "@types/node": ">=18.0.0" } }, "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA=="],
 
@@ -511,27 +515,27 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@storybook/addon-a11y": ["@storybook/addon-a11y@10.2.9", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.2.9" } }, "sha512-oWho1jJXS1QfjShin9yC2o60pvkPskgpqUDB5Of4XHFpOaV4hVfoqS1HjhZBQyjWZkN64EE42X3HVlwUwToPfg=="],
+    "@storybook/addon-a11y": ["@storybook/addon-a11y@10.2.12", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.2.12" } }, "sha512-UFJU9cOqaOLcb6WnO/y0urB6EUqPCxtNvIsiJ1MviCm9IqV+b3Y84NFxWYvYSBuYzqt89DKdh19edP6aVaLe6w=="],
 
-    "@storybook/addon-docs": ["@storybook/addon-docs@10.2.9", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.2.9", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.2.9", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.9" } }, "sha512-rPUSyymt6IDI8PbZVEXPnqOysstp+mKeZiPRxcKIklecDhLUiy5Yc2PQneYY//Gp7Z/CEe54tJHr+WpFgtLPYg=="],
+    "@storybook/addon-docs": ["@storybook/addon-docs@10.2.12", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.2.12", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.2.12", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.12" } }, "sha512-LlLQSYxISugG2mEVVV/rNMyZaF1wIvIhaq5kGKbBuAz18GOtQmvaa/o3fJjlebmvTn/AOmipNlQ4ChOXSAwmdg=="],
 
-    "@storybook/addon-vitest": ["@storybook/addon-vitest@10.2.9", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1" }, "peerDependencies": { "@vitest/browser": "^3.0.0 || ^4.0.0", "@vitest/browser-playwright": "^4.0.0", "@vitest/runner": "^3.0.0 || ^4.0.0", "storybook": "^10.2.9", "vitest": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@vitest/browser", "@vitest/browser-playwright", "@vitest/runner", "vitest"] }, "sha512-KZViI6jfE4lZb8lfti4sSb2mEj3jXGRy/d6fQxTM6gheS2A6WWuV5LmSArCMz9KqhSitu1Vy+rYhwkz97fecGw=="],
+    "@storybook/addon-vitest": ["@storybook/addon-vitest@10.2.12", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1" }, "peerDependencies": { "@vitest/browser": "^3.0.0 || ^4.0.0", "@vitest/browser-playwright": "^4.0.0", "@vitest/runner": "^3.0.0 || ^4.0.0", "storybook": "^10.2.12", "vitest": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@vitest/browser", "@vitest/browser-playwright", "@vitest/runner", "vitest"] }, "sha512-HvYHO+soQR4nlgNqoWBbuxHaTtdrggzCCE6evmcgP4aQzN/jCStPAa7DEV5vNwJ3E0YzAYfT4RSA3txOQVWOGQ=="],
 
-    "@storybook/builder-vite": ["@storybook/builder-vite@10.2.9", "", { "dependencies": { "@storybook/csf-plugin": "10.2.9", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-01DvThkchYqHh2GzqFTNrrNsrn3URuHXfHlDt2u+ggqiBKjObxeRhlgZN0ntG9w41Y05mhWH9pRAKbPMGDBIwQ=="],
+    "@storybook/builder-vite": ["@storybook/builder-vite@10.2.12", "", { "dependencies": { "@storybook/csf-plugin": "10.2.12", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.12", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-QaOwhNpoBs4Af8xYG1NOoyOvbapcN7EpwYq53ERpMz2uU+yOeApqy4XeJ5xM7doCvkJKZqidwLMXZQeN/j/mUw=="],
 
-    "@storybook/csf-plugin": ["@storybook/csf-plugin@10.2.9", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.2.9", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-vfGZeszuDZc742eQgpA/W6ok54ePYPYz9MLdM6u3XBHJXmNhsjbcwSFTXZHrxjyDn88vXdo+Frg3HBKkOQBnbQ=="],
+    "@storybook/csf-plugin": ["@storybook/csf-plugin@10.2.12", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.2.12", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-+6nv7oX21K+BRmMUCfeaFeS3UFgDu5/2M4YsLYzXnx/YmAP3yg0bb09falzvCKTCncHCJUWaO8GDvavj32anaA=="],
 
     "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
 
     "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
 
-    "@storybook/nextjs-vite": ["@storybook/nextjs-vite@10.2.9", "", { "dependencies": { "@storybook/builder-vite": "10.2.9", "@storybook/react": "10.2.9", "@storybook/react-vite": "10.2.9", "styled-jsx": "5.1.6", "vite-plugin-storybook-nextjs": "^3.1.9" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-ai/mKbx5kV4BR/J4yNPoSZSlZLeaJOGdBMlme5YUq5MwanJY+AM0uZu8PQ4j8SxdlFeXBGSuoZAOpKOHi8z2bA=="],
+    "@storybook/nextjs-vite": ["@storybook/nextjs-vite@10.2.12", "", { "dependencies": { "@storybook/builder-vite": "10.2.12", "@storybook/react": "10.2.12", "@storybook/react-vite": "10.2.12", "styled-jsx": "5.1.6", "vite-plugin-storybook-nextjs": "^3.1.9" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.12", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-p505ZCNklu2M7gSbdwHtu1Oo0eob4G1lzARAsPcevvcR2wBrr9WF4a9l3s+BPuVQcFbGv2hXMp4UkMJowfdFGQ=="],
 
-    "@storybook/react": ["@storybook/react@10.2.9", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.2.9", "react-docgen": "^8.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.9", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-cYJroaHWHmauPO8EcfpDTU3Odc7z5/DbuLO+jQ4SAaoupwnE35HNe8WAdpD3jpmI20cqKauqOENIT/+HjxhlYA=="],
+    "@storybook/react": ["@storybook/react@10.2.12", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.2.12", "react-docgen": "^8.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.12", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-7HV/qwEmrDK27FzVHt0/yr8Wu3UTVR9jez3p07M+l/+deIpYrlPiSWm/aoD60gN6kUKzxbeLJFJruS/OM9xnPA=="],
 
-    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.2.9", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.9" } }, "sha512-hlvFl0ylK/RZ4GxOXcBfzQNoOm3/x0LEgaPYlkR2/P4CTbKKTc+fHRsZMpFgP/X0g8oZmfm93mdhQdX0zlF8JQ=="],
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.2.12", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.12" } }, "sha512-T4uHPAgtEbroRazubGDIByopvNw1WKAp1kOlNqKWR8LZPDaVyEr8X7J6zaJo1y+vE8j6fUXvk6jZVMwhi/Jeig=="],
 
-    "@storybook/react-vite": ["@storybook/react-vite@10.2.9", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.4", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.2.9", "@storybook/react": "10.2.9", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-uDuo8TeBc3E519xQQGGGaH43TaCEbEgNjDV3vX/G6ikWgJoYzFFILO4EKhKKsf7t3dJl+FIXJEcvPw7Azd0VPw=="],
+    "@storybook/react-vite": ["@storybook/react-vite@10.2.12", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.4", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.2.12", "@storybook/react": "10.2.12", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.12", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-y5326n/fJBSUzBtSmVigu1W/NKAqvEQ23DEBNO3sK29TAxQyTM5oaYket9zHqPT3Eb3M1t9+TNCFUZSQ6yOTvQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -583,7 +587,7 @@
 
     "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
 
-    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -601,25 +605,25 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/type-utils": "8.56.0", "@typescript-eslint/utils": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.56.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.56.0", "@typescript-eslint/types": "^8.56.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.56.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.56.1", "@typescript-eslint/types": "^8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0" } }, "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.56.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.56.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/utils": "8.56.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.56.0", "", {}, "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.56.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.56.0", "@typescript-eslint/tsconfig-utils": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "debug": "^4.4.3", "minimatch": "^9.0.5", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.56.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.56.1", "@typescript-eslint/tsconfig-utils": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/types": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
 
     "@vitest/browser": ["@vitest/browser@4.0.18", "", { "dependencies": { "@vitest/mocker": "4.0.18", "@vitest/utils": "4.0.18", "magic-string": "^0.30.21", "pixelmatch": "7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.0.3", "ws": "^8.18.3" }, "peerDependencies": { "vitest": "4.0.18" } }, "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng=="],
 
@@ -641,11 +645,11 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -697,9 +701,9 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
-    "better-auth": ["better-auth@1.4.18", "", { "dependencies": { "@better-auth/core": "1.4.18", "@better-auth/telemetry": "1.4.18", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg=="],
+    "better-auth": ["better-auth@1.4.19", "", { "dependencies": { "@better-auth/core": "1.4.19", "@better-auth/telemetry": "1.4.19", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-3RlZJcA0+NH25wYD85vpIGwW9oSTuEmLIaGbT8zg41w/Pa2hVWHKedjoUHHJtnzkBXzDb+CShkLnSw7IThDdqQ=="],
 
     "better-call": ["better-call@1.1.8", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw=="],
 
@@ -727,7 +731,7 @@
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
@@ -739,7 +743,7 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "chromatic": ["chromatic@15.1.1", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-T42eLy1fuckVIzZAoryYjxOEFXgOC9BUi+oT0VjmCz9PaJ/tvItTagIxIxA65vgrtCymXKSZDrGe7Hg2y7iAMA=="],
+    "chromatic": ["chromatic@15.2.0", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-c9tDfE62aiPVPnVab8jQLz+9c9II/CUFZ6T2Kk3hi2hSL+HLkRwX3zjwRYW1z9Shn57R/ORBEpQ3ftufp8EgWA=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -831,13 +835,13 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.302", "", {}, "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
 
@@ -865,7 +869,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+    "eslint": ["eslint@9.39.3", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.3", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg=="],
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
@@ -957,7 +961,7 @@
 
     "git-hooks-list": ["git-hooks-list@4.2.1", "", {}, "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw=="],
 
-    "glob": ["glob@13.0.5", "", { "dependencies": { "minimatch": "^10.2.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -971,9 +975,9 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
+    "graphql": ["graphql@16.13.0", "", {}, "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA=="],
 
-    "happy-dom": ["happy-dom@20.6.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^6.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-+0vhESXXhFwkdjZnJ5DlmJIfUYGgIEEjzIjB+aKJbFuqlvvKyOi+XkI1fYbgYR9QCxG5T08koxsQ6HrQfa5gCQ=="],
+    "happy-dom": ["happy-dom@20.7.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1095,8 +1099,6 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
-    "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
-
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
@@ -1169,11 +1171,11 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "module-alias": ["module-alias@2.3.4", "", {}, "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w=="],
 
@@ -1261,7 +1263,7 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -1367,7 +1369,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
@@ -1437,7 +1439,7 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "storybook": ["storybook@10.2.9", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1", "@testing-library/jest-dom": "^6.6.3", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0", "open": "^10.2.0", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": "./dist/bin/dispatcher.js" }, "sha512-DGok7XwIwdPWF+a49Yw+4madER5DZWRo9CdyySBLT3zeuxiEPt0Ua7ouJHm/y6ojnb/FVKZcQe8YmrE71s0qPQ=="],
+    "storybook": ["storybook@10.2.12", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1", "@testing-library/jest-dom": "^6.6.3", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0", "open": "^10.2.0", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": "./dist/bin/dispatcher.js" }, "sha512-eT4266OqLdRE3J/pxl2dk36Rnj9vv17Y6rNMpzxohOMjRVONyKkozUd6gaZ2C4WUcwYdIw6VE+ft4LwrJXt/4Q=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
@@ -1473,7 +1475,7 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwind-merge": ["tailwind-merge@3.4.1", "", {}, "sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q=="],
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 
@@ -1533,11 +1535,11 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.56.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.0", "@typescript-eslint/parser": "8.56.0", "@typescript-eslint/typescript-estree": "8.56.0", "@typescript-eslint/utils": "8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg=="],
+    "typescript-eslint": ["typescript-eslint@8.56.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.1", "@typescript-eslint/parser": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -1559,7 +1561,7 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
-    "vite-plugin-storybook-nextjs": ["vite-plugin-storybook-nextjs@3.1.12", "", { "dependencies": { "@next/env": "16.0.0", "image-size": "^2.0.0", "magic-string": "^0.30.11", "module-alias": "^2.2.3", "ts-dedent": "^2.2.0", "vite-tsconfig-paths": "^5.1.4" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "storybook": "^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-/9qKlYWHVXz6AnQBngxD+v26fbdfVaTXeQqVQOvWocOE03FV+sdkwVsallJbmb8iMrkO36G7iLd2T1J0BXUIVQ=="],
+    "vite-plugin-storybook-nextjs": ["vite-plugin-storybook-nextjs@3.2.2", "", { "dependencies": { "@next/env": "16.0.0", "image-size": "^2.0.0", "magic-string": "^0.30.11", "module-alias": "^2.2.3", "ts-dedent": "^2.2.0", "vite-tsconfig-paths": "^5.1.4" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "storybook": "^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-ZJXCrhi9mW4jEJTKhJ5sUtpBe84mylU40me2aMuLSgIJo4gE/Rc559hZvMYLFTWta1gX7Rm8Co5EEHakPct+wA=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
@@ -1625,39 +1627,17 @@
 
     "@inquirer/core/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-popper/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+    "@radix-ui/react-progress/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
-    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-radio-group/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
-
-    "@radix-ui/react-radio-group/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-select/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
-
-    "@radix-ui/react-select/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-progress/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -1669,11 +1649,11 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -1705,7 +1685,7 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "glob/minimatch": ["minimatch@10.2.1", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A=="],
+    "glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "istanbul-lib-instrument/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1817,23 +1797,7 @@
 
     "@inquirer/core/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popper/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-radio-group/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
@@ -1843,7 +1807,7 @@
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "msw/@inquirer/confirm/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
 
@@ -1961,7 +1925,9 @@
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "msw/@inquirer/confirm/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
   }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -45,11 +45,13 @@
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",
+    "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@slack/web-api": "^7.13.0",
     "@t3-oss/env-nextjs": "^0.9.2",
     "@tanstack/react-query": "^5.90.19",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,114 +7,114 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = "2.12.7";
-const INTEGRITY_CHECKSUM = "4db4a41e972cec1b64cc569c66952d82";
-const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.12.10'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
-addEventListener("install", function () {
-  self.skipWaiting();
-});
+addEventListener('install', function () {
+  self.skipWaiting()
+})
 
-addEventListener("activate", function (event) {
-  event.waitUntil(self.clients.claim());
-});
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
 
-addEventListener("message", async function (event) {
-  const clientId = Reflect.get(event.source || {}, "id");
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
-    type: "window",
-  });
+    type: 'window',
+  })
 
   switch (event.data) {
-    case "KEEPALIVE_REQUEST": {
+    case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
-        type: "KEEPALIVE_RESPONSE",
-      });
-      break;
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
     }
 
-    case "INTEGRITY_CHECK_REQUEST": {
+    case 'INTEGRITY_CHECK_REQUEST': {
       sendToClient(client, {
-        type: "INTEGRITY_CHECK_RESPONSE",
+        type: 'INTEGRITY_CHECK_RESPONSE',
         payload: {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      });
-      break;
+      })
+      break
     }
 
-    case "MOCK_ACTIVATE": {
-      activeClientIds.add(clientId);
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
-        type: "MOCKING_ENABLED",
+        type: 'MOCKING_ENABLED',
         payload: {
           client: {
             id: client.id,
             frameType: client.frameType,
           },
         },
-      });
-      break;
+      })
+      break
     }
 
-    case "CLIENT_CLOSED": {
-      activeClientIds.delete(clientId);
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
-addEventListener("fetch", function (event) {
-  const requestInterceptedAt = Date.now();
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
 
   // Bypass navigation requests.
-  if (event.request.mode === "navigate") {
-    return;
+  if (event.request.mode === 'navigate') {
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
   if (
-    event.request.cache === "only-if-cached" &&
-    event.request.mode !== "same-origin"
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
   ) {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId, requestInterceptedAt));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
 
 /**
  * @param {FetchEvent} event
@@ -122,28 +122,28 @@ addEventListener("fetch", function (event) {
  * @param {number} requestInterceptedAt
  */
 async function handleRequest(event, requestId, requestInterceptedAt) {
-  const client = await resolveMainClient(event);
-  const requestCloneForEvents = event.request.clone();
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
   const response = await getResponse(
     event,
     client,
     requestId,
     requestInterceptedAt,
-  );
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    const serializedRequest = await serializeRequest(requestCloneForEvents);
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone();
+    const responseClone = response.clone()
 
     sendToClient(
       client,
       {
-        type: "RESPONSE",
+        type: 'RESPONSE',
         payload: {
           isMockedResponse: IS_MOCKED_RESPONSE in response,
           request: {
@@ -160,10 +160,10 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
         },
       },
       responseClone.body ? [serializedRequest.body, responseClone.body] : [],
-    );
+    )
   }
 
-  return response;
+  return response
 }
 
 /**
@@ -175,30 +175,30 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
  * @returns {Promise<Client | undefined>}
  */
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (activeClientIds.has(event.clientId)) {
-    return client;
+    return client
   }
 
-  if (client?.frameType === "top-level") {
-    return client;
+  if (client?.frameType === 'top-level') {
+    return client
   }
 
   const allClients = await self.clients.matchAll({
-    type: "window",
-  });
+    type: 'window',
+  })
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === "visible";
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 /**
@@ -211,36 +211,36 @@ async function resolveMainClient(event) {
 async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = event.request.clone();
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers);
+    const headers = new Headers(requestClone.headers)
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get("accept");
+    const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(",").map((value) => value.trim());
+      const values = acceptHeader.split(',').map((value) => value.trim())
       const filteredValues = values.filter(
-        (value) => value !== "msw/passthrough",
-      );
+        (value) => value !== 'msw/passthrough',
+      )
 
       if (filteredValues.length > 0) {
-        headers.set("accept", filteredValues.join(", "));
+        headers.set('accept', filteredValues.join(', '))
       } else {
-        headers.delete("accept");
+        headers.delete('accept')
       }
     }
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -248,15 +248,15 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const serializedRequest = await serializeRequest(event.request);
+  const serializedRequest = await serializeRequest(event.request)
   const clientMessage = await sendToClient(
     client,
     {
-      type: "REQUEST",
+      type: 'REQUEST',
       payload: {
         id: requestId,
         interceptedAt: requestInterceptedAt,
@@ -264,19 +264,19 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
       },
     },
     [serializedRequest.body],
-  );
+  )
 
   switch (clientMessage.type) {
-    case "MOCK_RESPONSE": {
-      return respondWithMock(clientMessage.data);
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
     }
 
-    case "PASSTHROUGH": {
-      return passthrough();
+    case 'PASSTHROUGH': {
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 /**
@@ -287,21 +287,21 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
  */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
     client.postMessage(message, [
       channel.port2,
       ...transferrables.filter(Boolean),
-    ]);
-  });
+    ])
+  })
 }
 
 /**
@@ -314,17 +314,17 @@ function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  });
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }
 
 /**
@@ -345,5 +345,5 @@ async function serializeRequest(request) {
     referrerPolicy: request.referrerPolicy,
     body: await request.arrayBuffer(),
     keepalive: request.keepalive,
-  };
+  }
 }

--- a/src/app/(auth)/complete-profile/complete-profile-form.tsx
+++ b/src/app/(auth)/complete-profile/complete-profile-form.tsx
@@ -65,15 +65,16 @@ export default function CompleteProfileForm({ callbackUrl }: CompleteProfileForm
   // Super edge case and should realistically only happen if we mess up in the future
   // or meddle with the database directly.
   React.useEffect(() => {
-    if (!me) return;
+    if (!me?.profile) return;
 
-    setStatus(me.status as Status);
-    setDivision(me.division as Division);
-    setLastActiveYear(me.lastActiveYear ? String(me.lastActiveYear) : "");
+    const p = me.profile;
+    setStatus(p.status);
+    setDivision(p.division as Division);
+    setLastActiveYear(p.lastActiveYear ? String(p.lastActiveYear) : "");
 
-    const dbTeam = me.team as Team;
+    const dbTeam = p.team as Team;
     setTeam(dbTeam);
-    setTeamOther(me.teamOther ?? "");
+    setTeamOther(p.teamOther ?? "");
   }, [me]);
 
   // 4. Effect: Reset Team if Division changes

--- a/src/app/(auth)/complete-profile/page.tsx
+++ b/src/app/(auth)/complete-profile/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@/lib/auth";
-import { isValidRedirectPath, safeDecodeURIComponent } from "@/lib/utils";
+import { buildLoginRedirect, resolveCallbackUrl } from "@/lib/utils";
 import { db } from "@/server/db";
 import { memberProfile } from "@/server/db/schema";
 import { eq } from "drizzle-orm";
@@ -22,7 +22,10 @@ export default async function CompleteProfilePageWrapper(props: CompleteProfileP
   });
 
   if (!session?.user?.id) {
-    redirect("/login");
+    const loginPath = rawCallbackUrl
+      ? `/complete-profile?callbackUrl=${encodeURIComponent(rawCallbackUrl)}`
+      : "/complete-profile";
+    redirect(buildLoginRedirect(loginPath));
   }
 
   // Check if profile is already complete
@@ -33,19 +36,9 @@ export default async function CompleteProfilePageWrapper(props: CompleteProfileP
     .limit(1);
 
   const isComplete = row[0]?.isProfileComplete ?? false;
+  const destination = resolveCallbackUrl(rawCallbackUrl);
 
-  // 2. Resolve safe redirect URL
-  let destination = "/dashboard";
-
-  // FIX: Use rawCallbackUrl instead of the undefined 'next' variable
-  if (rawCallbackUrl) {
-    const decoded = safeDecodeURIComponent(rawCallbackUrl);
-    if (decoded && isValidRedirectPath(decoded)) {
-      destination = decoded;
-    }
-  }
-
-  // 3. If complete, forward immediately to the destination
+  // If complete, forward immediately to the destination
   if (isComplete) {
     redirect(destination);
   }

--- a/src/app/(auth)/post-auth/page.tsx
+++ b/src/app/(auth)/post-auth/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
-import { isValidRedirectPath, safeDecodeURIComponent } from "@/lib/utils";
+import { buildLoginRedirect, isValidRedirectPath, safeDecodeURIComponent } from "@/lib/utils";
 import { db } from "@/server/db";
 import { memberProfile } from "@/server/db/schema";
 
@@ -22,7 +22,11 @@ export default async function PostAuthPage(props: PostAuthPageProps) {
   });
 
   if (!session) {
-    redirect("/login");
+    // Pass the final destination directly to login.
+    // The login page already routes through post-auth after OAuth.
+    const destination =
+      callbackUrl && isValidRedirectPath(callbackUrl) ? callbackUrl : "/dashboard";
+    redirect(buildLoginRedirect(destination));
   }
 
   const profile = await db.query.memberProfile.findFirst({

--- a/src/app/(mobile)/dashboard/dashboard-page.stories.tsx
+++ b/src/app/(mobile)/dashboard/dashboard-page.stories.tsx
@@ -1,0 +1,71 @@
+/**
+ * Stories for the Dashboard page layout.
+ *
+ * Shows the full mobile app shell with dashboard content.
+ */
+
+import { AppFooter } from "@/components/layout/app-footer";
+import { AppHeader } from "@/components/layout/app-header";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const meta = {
+  title: "Pages/Dashboard",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/dashboard",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DashboardLayout({ userName }: { userName: string }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <AppHeader
+        user={{
+          name: userName,
+          image: "https://i.pravatar.cc/32?u=dashboard",
+        }}
+      />
+      <main className="flex-1 pb-20">
+        <div className="mx-auto w-full max-w-3xl px-4 py-8">
+          <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
+          <p className="mt-2 text-muted-foreground">Welcome back, {userName}!</p>
+          {/* TODO: Dashboard content placeholder */}
+          <div className="mt-6 grid gap-4">
+            <div className="h-32 rounded-xl border border-border bg-white p-4 shadow-sm">
+              <div className="text-sm font-medium text-muted-foreground">Upcoming Shifts</div>
+              <div className="mt-2 text-lg font-semibold text-foreground">3 this week</div>
+            </div>
+            <div className="h-32 rounded-xl border border-border bg-white p-4 shadow-sm">
+              <div className="text-sm font-medium text-muted-foreground">Team Updates</div>
+              <div className="mt-2 text-lg font-semibold text-foreground">No new updates</div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <AppFooter />
+    </div>
+  );
+}
+
+/**
+ * Default dashboard view.
+ */
+export const Default: Story = {
+  render: () => <DashboardLayout userName="Max Mustermann" />,
+};
+
+/**
+ * Dashboard for a different user.
+ */
+export const DifferentUser: Story = {
+  render: () => <DashboardLayout userName="Anna Schmidt" />,
+};

--- a/src/app/(mobile)/dashboard/page.tsx
+++ b/src/app/(mobile)/dashboard/page.tsx
@@ -1,0 +1,21 @@
+import { auth } from "@/lib/auth";
+import { buildLoginRedirect } from "@/lib/utils";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function DashboardPage() {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  if (!session?.user?.id) {
+    redirect(buildLoginRedirect("/dashboard"));
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
+      <p className="mt-2 text-muted-foreground">Welcome back, {session.user.name}!</p>
+      {/* TODO: Dashboard content */}
+    </div>
+  );
+}

--- a/src/app/(mobile)/layout.tsx
+++ b/src/app/(mobile)/layout.tsx
@@ -1,0 +1,19 @@
+import { AppFooter } from "@/components/layout/app-footer";
+import { AppHeader } from "@/components/layout/app-header";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+
+export default async function MobileLayout({ children }: { children: React.ReactNode }) {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  const user = session?.user ? { name: session.user.name, image: session.user.image } : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <AppHeader user={user} />
+      <main className="flex-1 pb-20">{children}</main>
+      <AppFooter />
+    </div>
+  );
+}

--- a/src/app/(mobile)/profile/[id]/page.tsx
+++ b/src/app/(mobile)/profile/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { MemberProfileView } from "@/components/profile/member-profile-view";
+import { auth } from "@/lib/auth";
+import { buildLoginRedirect } from "@/lib/utils";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function MemberProfilePage({ params }: { params: Promise<{ id: string }> }) {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  if (!session?.user?.id) {
+    const { id } = await params;
+    redirect(buildLoginRedirect(`/profile/${id}`));
+  }
+
+  const { id } = await params;
+
+  // If user is viewing their own profile, redirect to the editable version
+  if (id === session.user.id) {
+    redirect("/profile");
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <MemberProfileView userId={id} />
+    </div>
+  );
+}

--- a/src/app/(mobile)/profile/page.tsx
+++ b/src/app/(mobile)/profile/page.tsx
@@ -1,0 +1,20 @@
+import { ProfileForm } from "@/components/profile/profile-form";
+import { auth } from "@/lib/auth";
+import { buildLoginRedirect } from "@/lib/utils";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function ProfilePage() {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  if (!session?.user?.id) {
+    redirect(buildLoginRedirect("/profile"));
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <ProfileForm />
+    </div>
+  );
+}

--- a/src/app/(mobile)/profile/profile-page.stories.tsx
+++ b/src/app/(mobile)/profile/profile-page.stories.tsx
@@ -1,0 +1,107 @@
+/**
+ * Stories for the Profile page layout.
+ *
+ * Shows the full mobile app shell with profile form.
+ */
+
+import { AppFooter } from "@/components/layout/app-footer";
+import { AppHeader } from "@/components/layout/app-header";
+import { ProfileForm } from "@/components/profile/profile-form";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { trpcMutation, trpcQuery } from "../../../../.storybook/utils/trpc-helpers";
+
+const meta = {
+  title: "Pages/Profile",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/profile",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock data
+const mockUser = {
+  name: "Max Mustermann",
+  image: "https://i.pravatar.cc/96?u=profile",
+};
+
+const mockProfile = {
+  userId: "user-1",
+  status: "active" as const,
+  division: "operations",
+  team: "concept", // Valid team for operations division
+  lastActiveYear: null,
+  teamOther: null,
+  phoneNumber: "+49 170 1234567",
+  privateEmail: "max@example.com",
+  linkedInUrl: "https://linkedin.com/in/maxmustermann",
+  isProfileComplete: true,
+  talentIds: ["driver_18plus", "gastro"],
+};
+
+const mockTalents = [
+  { id: "driver_18plus", category: "driver_license", key: "driver_18plus" },
+  { id: "driver_21plus", category: "driver_license", key: "driver_21plus" },
+  { id: "driver_c1", category: "driver_license", key: "driver_c1" },
+  { id: "gastro", category: "gastronomy", key: "gastro" },
+];
+
+function ProfilePageLayout() {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <AppHeader user={mockUser} />
+      <main className="flex-1 pb-20">
+        <div className="mx-auto w-full max-w-3xl px-4 py-8">
+          <ProfileForm />
+        </div>
+      </main>
+      <AppFooter />
+    </div>
+  );
+}
+
+/**
+ * Profile page with existing data.
+ */
+export const WithProfile: Story = {
+  render: () => <ProfilePageLayout />,
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockProfile,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("profile", "update", () => ({ ok: true })),
+      ],
+    },
+  },
+};
+
+/**
+ * Profile page for new user.
+ */
+export const NewUser: Story = {
+  render: () => <ProfilePageLayout />,
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: { name: "New User", image: null },
+          profile: null,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("profile", "update", () => ({ ok: true })),
+      ],
+    },
+  },
+};

--- a/src/app/(mobile)/profiles/page.tsx
+++ b/src/app/(mobile)/profiles/page.tsx
@@ -1,0 +1,21 @@
+import { MemberList } from "@/components/profile/member-list";
+import { auth } from "@/lib/auth";
+import { buildLoginRedirect } from "@/lib/utils";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function ProfilesPage() {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  if (!session?.user?.id) {
+    redirect(buildLoginRedirect("/profiles"));
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-foreground">Members</h1>
+      <MemberList />
+    </div>
+  );
+}

--- a/src/app/(mobile)/shifts/page.tsx
+++ b/src/app/(mobile)/shifts/page.tsx
@@ -1,0 +1,21 @@
+import { auth } from "@/lib/auth";
+import { buildLoginRedirect } from "@/lib/utils";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function ShiftsPage() {
+  const h = await headers();
+  const session = await auth.api.getSession({ headers: new Headers(h) });
+
+  if (!session?.user?.id) {
+    redirect(buildLoginRedirect("/shifts"));
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
+      <p className="mt-2 text-muted-foreground">Your upcoming shifts will appear here.</p>
+      {/* TODO: Shifts list */}
+    </div>
+  );
+}

--- a/src/app/(mobile)/shifts/shifts-page.stories.tsx
+++ b/src/app/(mobile)/shifts/shifts-page.stories.tsx
@@ -1,0 +1,128 @@
+/**
+ * Stories for the Shifts page layout.
+ *
+ * Shows the full mobile app shell with shifts content.
+ */
+
+import { AppFooter } from "@/components/layout/app-footer";
+import { AppHeader } from "@/components/layout/app-header";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Calendar, Clock, MapPin } from "lucide-react";
+
+const meta = {
+  title: "Pages/Shifts",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/shifts",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+interface Shift {
+  id: string;
+  date: string;
+  time: string;
+  location: string;
+  role: string;
+}
+
+function ShiftCard({ shift }: { shift: Shift }) {
+  return (
+    <div className="rounded-xl border border-border bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="font-semibold text-foreground">{shift.role}</div>
+          <div className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4" />
+              <span>{shift.date}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4" />
+              <span>{shift.time}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4" />
+              <span>{shift.location}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShiftsLayout({ shifts }: { shifts: Shift[] }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <AppHeader
+        user={{
+          name: "Max Mustermann",
+          image: "https://i.pravatar.cc/32?u=shifts",
+        }}
+      />
+      <main className="flex-1 pb-20">
+        <div className="mx-auto w-full max-w-3xl px-4 py-8">
+          <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
+          <p className="mt-2 text-muted-foreground">
+            {shifts.length > 0 ? "Your upcoming shifts" : "Your upcoming shifts will appear here."}
+          </p>
+          {shifts.length > 0 && (
+            <div className="mt-6 grid gap-3">
+              {shifts.map((shift) => (
+                <ShiftCard key={shift.id} shift={shift} />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+      <AppFooter />
+    </div>
+  );
+}
+
+const mockShifts: Shift[] = [
+  {
+    id: "1",
+    date: "Friday, Feb 27",
+    time: "14:00 - 22:00",
+    location: "Main Stage",
+    role: "Runner",
+  },
+  {
+    id: "2",
+    date: "Saturday, Feb 28",
+    time: "10:00 - 18:00",
+    location: "Catering Area",
+    role: "Gastro Support",
+  },
+  {
+    id: "3",
+    date: "Sunday, Mar 1",
+    time: "08:00 - 16:00",
+    location: "Logistics Hub",
+    role: "Driver (C1)",
+  },
+];
+
+/**
+ * Shifts page with upcoming shifts.
+ */
+export const WithShifts: Story = {
+  render: () => <ShiftsLayout shifts={mockShifts} />,
+};
+
+/**
+ * Shifts page with no upcoming shifts.
+ */
+export const EmptyState: Story = {
+  render: () => <ShiftsLayout shifts={[]} />,
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,6 @@
-import { Button } from "@/components/ui/button";
+import { redirect } from "next/navigation";
 
-export default async function HomePage() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white">
-      <div className="container flex flex-col items-center justify-center gap-12 px-4 py-16">
-        <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem]">
-          Q <span className="text-[hsl(280,100%,70%)]">Portal</span>
-        </h1>
-        <div className="flex flex-col items-center gap-4">
-          <p className="text-2xl text-white">No text here.</p>
-          <Button variant="default" size="lg">
-            Test Button
-          </Button>
-        </div>
-      </div>
-    </main>
-  );
+export default function HomePage() {
+  // Redirect to post-auth which handles login check and profile completion
+  redirect("/post-auth?callbackUrl=%2Fdashboard");
 }

--- a/src/components/auth/auth-scrollable-card.tsx
+++ b/src/components/auth/auth-scrollable-card.tsx
@@ -68,8 +68,8 @@ export function AuthScrollableCard({
         </CardHeader>
 
         {/* Scrollable Content */}
-        {/* Changed 'grid' to 'flex flex-col' for better alignment control */}
         <CardContent
+          tabIndex={0}
           className={cn(
             "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-10 py-4",
             contentClassName,

--- a/src/components/layout/app-footer.stories.tsx
+++ b/src/components/layout/app-footer.stories.tsx
@@ -1,0 +1,68 @@
+/**
+ * Stories for the AppFooter navigation component.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AppFooter } from "./app-footer";
+
+const meta = {
+  title: "Layout/AppFooter",
+  component: AppFooter,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="relative h-screen bg-slate-50">
+        <div className="h-full" />
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AppFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Footer with Dashboard active.
+ */
+export const DashboardActive: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/dashboard",
+      },
+    },
+  },
+};
+
+/**
+ * Footer with Shifts active.
+ */
+export const ShiftsActive: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/shifts",
+      },
+    },
+  },
+};
+
+/**
+ * Footer with Profile active.
+ */
+export const ProfileActive: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/profile",
+      },
+    },
+  },
+};

--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Calendar, LayoutGrid, User, Users } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutGrid },
+  { href: "/shifts", label: "Shifts", icon: Calendar },
+  { href: "/profiles", label: "Members", icon: Users },
+  { href: "/profile", label: "Profile", icon: User },
+] as const;
+
+export function AppFooter() {
+  const pathname = usePathname();
+
+  return (
+    <footer className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-white">
+      <nav className="flex items-center justify-around px-4 py-2 pb-[env(safe-area-inset-bottom)]">
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+          const isActive =
+            href === "/profile" ? pathname === "/profile" : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex flex-col items-center gap-1 px-4 py-2 transition-colors ${
+                isActive ? "text-primary" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Icon className="h-6 w-6" />
+              <span className="text-[10px] font-medium">{label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </footer>
+  );
+}

--- a/src/components/layout/app-header.stories.tsx
+++ b/src/components/layout/app-header.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * Stories for the AppHeader component.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AppHeader } from "./app-header";
+
+const meta = {
+  title: "Layout/AppHeader",
+  component: AppHeader,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AppHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Header with logged in user (with avatar).
+ */
+export const WithUser: Story = {
+  args: {
+    user: {
+      name: "Max Mustermann",
+      image: "https://i.pravatar.cc/32?u=max",
+    },
+  },
+};
+
+/**
+ * Header with user but no avatar.
+ */
+export const WithUserNoAvatar: Story = {
+  args: {
+    user: {
+      name: "Max Mustermann",
+      image: null,
+    },
+  },
+};
+
+/**
+ * Header without user (logged out state).
+ */
+export const NoUser: Story = {
+  args: {
+    user: undefined,
+  },
+};

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -1,0 +1,43 @@
+import logoImg from "@/assets/logo_blue.png";
+import { User } from "lucide-react";
+import Image from "next/image";
+
+interface AppHeaderProps {
+  user?: {
+    name?: string | null;
+    image?: string | null;
+  };
+}
+
+export function AppHeader({ user }: AppHeaderProps) {
+  return (
+    <header className="flex items-center justify-between border-b border-border/50 bg-white px-6 py-4">
+      <div className="flex items-center gap-3">
+        <Image
+          src={logoImg}
+          alt="Q-Summit Logo"
+          width={32}
+          height={32}
+          className="h-8 w-8 object-contain"
+          priority
+        />
+        <span className="font-bold text-foreground">Q-Portal</span>
+      </div>
+      <div className="h-8 w-8 overflow-hidden rounded-full bg-slate-200">
+        {user?.image ? (
+          <Image
+            src={user.image}
+            alt={user.name ?? "User"}
+            width={32}
+            height={32}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <User className="h-4 w-4" />
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/profile/member-list.tsx
+++ b/src/components/profile/member-list.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DIVISION_OPTIONS, TEAMS_BY_DIVISION, type Division } from "@/domain/qsum/profile";
+import { api } from "@/server/api/client";
+import { ChevronLeft, ChevronRight, Search, User, Users, X } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRef, useState } from "react";
+
+const PAGE_SIZE = 20;
+
+const YEAR_OPTIONS = Array.from({ length: 10 }, (_, i) => {
+  const y = new Date().getFullYear() - i;
+  return { value: y, label: String(y) };
+});
+
+/** Sentinel used to represent "no selection" in shadcn Select (which doesn't support undefined values). */
+const NONE = "__none__";
+
+export function MemberList() {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [cursor, setCursor] = useState(0);
+  const [division, setDivision] = useState<string | undefined>();
+  const [team, setTeam] = useState<string | undefined>();
+  const [year, setYear] = useState<number | undefined>();
+
+  const resetCursor = () => setCursor(0);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setDebouncedSearch(value);
+      resetCursor();
+    }, 300);
+  };
+
+  const teamOptions = division ? (TEAMS_BY_DIVISION[division as Division] ?? []) : [];
+
+  const activeFilterCount = [division, team, year].filter(Boolean).length;
+
+  const { data, isLoading } = api.profile.list.useQuery(
+    {
+      cursor,
+      limit: PAGE_SIZE,
+      search: debouncedSearch,
+      division,
+      team,
+      year,
+    },
+    { refetchOnWindowFocus: false },
+  );
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const hasNext = data?.nextCursor !== null && data?.nextCursor !== undefined;
+  const hasPrev = cursor > 0;
+  const currentPage = Math.floor(cursor / PAGE_SIZE) + 1;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="grid gap-4">
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          placeholder="Search members..."
+          className="h-11 rounded-xl pl-10"
+        />
+      </div>
+
+      {/* Filter Dropdowns */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={division ?? NONE}
+          onValueChange={(val) => {
+            setDivision(val === NONE ? undefined : val);
+            setTeam(undefined);
+            resetCursor();
+          }}
+        >
+          <SelectTrigger
+            className={`h-9 w-auto min-w-[130px] rounded-lg text-xs font-medium ${
+              division ? "border-primary/30 bg-primary/5 text-primary" : "text-muted-foreground"
+            }`}
+          >
+            <SelectValue placeholder="Board Area" />
+          </SelectTrigger>
+          <SelectContent className="bg-white">
+            <SelectItem value={NONE}>All Areas</SelectItem>
+            {DIVISION_OPTIONS.map((d) => (
+              <SelectItem key={d.value} value={d.value}>
+                {d.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={team ?? NONE}
+          onValueChange={(val) => {
+            setTeam(val === NONE ? undefined : val);
+            resetCursor();
+          }}
+          disabled={!division}
+        >
+          <SelectTrigger
+            className={`h-9 w-auto min-w-[110px] rounded-lg text-xs font-medium ${
+              team ? "border-primary/30 bg-primary/5 text-primary" : "text-muted-foreground"
+            }`}
+          >
+            <SelectValue placeholder="Team" />
+          </SelectTrigger>
+          <SelectContent className="bg-white">
+            <SelectItem value={NONE}>All Teams</SelectItem>
+            {teamOptions.map((t) => (
+              <SelectItem key={t.value} value={t.value}>
+                {t.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={year?.toString() ?? NONE}
+          onValueChange={(val) => {
+            setYear(val === NONE ? undefined : Number(val));
+            resetCursor();
+          }}
+        >
+          <SelectTrigger
+            className={`h-9 w-auto min-w-[90px] rounded-lg text-xs font-medium ${
+              year ? "border-primary/30 bg-primary/5 text-primary" : "text-muted-foreground"
+            }`}
+          >
+            <SelectValue placeholder="Year" />
+          </SelectTrigger>
+          <SelectContent className="bg-white">
+            <SelectItem value={NONE}>All Years</SelectItem>
+            {YEAR_OPTIONS.map((y) => (
+              <SelectItem key={y.value} value={String(y.value)}>
+                {y.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {activeFilterCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setDivision(undefined);
+              setTeam(undefined);
+              setYear(undefined);
+              resetCursor();
+            }}
+            className="h-9 gap-1 text-xs text-destructive hover:text-destructive"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Results Count */}
+      <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+        <Users className="h-3.5 w-3.5" />
+        {total} {total === 1 ? "member" : "members"} found
+      </div>
+
+      {/* Member Cards */}
+      {isLoading && items.length === 0 ? (
+        <div className="p-8 text-center text-muted-foreground">Loading members...</div>
+      ) : items.length === 0 ? (
+        <div className="rounded-2xl border border-border bg-white p-8 text-center text-muted-foreground shadow-sm">
+          {debouncedSearch && activeFilterCount > 0
+            ? `No members matching "${debouncedSearch}" with the selected filters.`
+            : debouncedSearch
+              ? `No members matching "${debouncedSearch}".`
+              : activeFilterCount > 0
+                ? "No members found with the selected filters."
+                : "No members found."}
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((member) => (
+            <MemberCard key={member.id} member={member} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setCursor(Math.max(0, cursor - PAGE_SIZE))}
+            disabled={!hasPrev}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setCursor(data?.nextCursor ?? cursor)}
+            disabled={!hasNext}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Member Card ───────────────────────────────────────────────────────── */
+
+function MemberCard({
+  member,
+}: {
+  member: {
+    id: string;
+    name: string;
+    image: string | null;
+    division: string;
+    team: string;
+    status: string;
+    lastActiveYear: number | null;
+  };
+}) {
+  const divisionLabel =
+    DIVISION_OPTIONS.find((d) => d.value === member.division)?.label ?? member.division;
+  const teamLabel = member.division
+    ? (TEAMS_BY_DIVISION[member.division as Division]?.find((t) => t.value === member.team)
+        ?.label ?? member.team)
+    : member.team;
+  const year = member.lastActiveYear ?? new Date().getFullYear();
+
+  return (
+    <Link
+      href={`/profile/${member.id}`}
+      className="flex items-center gap-4 rounded-2xl border border-border bg-white p-4 shadow-sm transition-colors hover:border-primary/30 hover:bg-primary/5"
+    >
+      <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-slate-200">
+        {member.image ? (
+          <Image
+            src={member.image}
+            alt={member.name}
+            width={48}
+            height={48}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-primary/10 text-primary">
+            <User className="h-5 w-5" />
+          </div>
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-semibold text-foreground">{member.name}</span>
+        <span className="text-xs text-muted-foreground">
+          {divisionLabel} · {teamLabel} · {year}
+          {member.status === "alumni" && " · Alumni"}
+        </span>
+      </div>
+      <svg
+        className="h-4 w-4 shrink-0 text-muted-foreground"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </Link>
+  );
+}

--- a/src/components/profile/member-profile-view.tsx
+++ b/src/components/profile/member-profile-view.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import {
+  DIVISION_OPTIONS,
+  TALENT_LABELS,
+  TEAMS_BY_DIVISION,
+  type Division,
+  type TalentKey,
+} from "@/domain/qsum/profile";
+import { api } from "@/server/api/client";
+import type { LucideIcon } from "lucide-react";
+import {
+  Car,
+  Check,
+  CheckCircle2,
+  Link as LinkIcon,
+  Mail,
+  Phone,
+  Truck,
+  User,
+  Utensils,
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+const TALENT_ICONS: Record<string, LucideIcon> = {
+  driver_18plus: Car,
+  driver_21plus: Car,
+  driver_c1: Truck,
+  gastro: Utensils,
+};
+
+export function MemberProfileView({ userId }: { userId: string }) {
+  const { data, isLoading, error } = api.profile.getByUserId.useQuery(
+    { userId },
+    { refetchOnWindowFocus: false },
+  );
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-muted-foreground">Loading profile...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center text-muted-foreground">
+        {error.data?.code === "NOT_FOUND" ? "Profile not found." : "Failed to load profile."}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const divisionLabel = data.division
+    ? (DIVISION_OPTIONS.find((d) => d.value === data.division)?.label ?? null)
+    : null;
+  const teamLabel =
+    data.division && data.team
+      ? (TEAMS_BY_DIVISION[data.division as Division]?.find((t) => t.value === data.team)?.label ??
+        null)
+      : null;
+  const displayYear = data.lastActiveYear?.toString() ?? new Date().getFullYear().toString();
+
+  return (
+    <div className="grid gap-8">
+      {/* Profile Header */}
+      <div className="relative flex flex-col items-center rounded-2xl border border-border bg-white p-6 shadow-sm">
+        <div className="relative mb-4">
+          <div className="h-24 w-24 overflow-hidden rounded-full border-4 border-white bg-slate-200 shadow-sm">
+            {data.image ? (
+              <Image
+                src={data.image}
+                alt={data.name ?? "Profile picture"}
+                width={96}
+                height={96}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-primary/10 text-primary">
+                <User className="h-10 w-10" />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="mb-1 flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-foreground">{data.name}</h1>
+          <span className="flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700">
+            <CheckCircle2 className="h-3 w-3" />
+            Verified
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {divisionLabel && teamLabel
+            ? `${divisionLabel} • ${teamLabel} • ${displayYear}`
+            : "Member"}
+        </p>
+      </div>
+
+      {/* Contact Information */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Contact Information</h2>
+        <div className="flex flex-col overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
+          <InfoRow
+            icon={Phone}
+            label="Phone Number"
+            value={data.phoneNumber ?? "Not provided"}
+            isEmpty={!data.phoneNumber}
+          />
+          <InfoRow
+            icon={Mail}
+            label="Private Email"
+            value={data.privateEmail ?? "Not provided"}
+            isEmpty={!data.privateEmail}
+          />
+          <InfoRow
+            icon={LinkIcon}
+            label="LinkedIn"
+            value={data.linkedInUrl ?? "Not provided"}
+            isEmpty={!data.linkedInUrl}
+            isLast
+            isLink={!!data.linkedInUrl}
+          />
+        </div>
+      </div>
+
+      {/* Talents */}
+      {data.talents.length > 0 && (
+        <div>
+          <div className="mb-3 flex items-end justify-between px-1">
+            <h2 className="text-lg font-bold text-foreground">Talents</h2>
+            <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+              SKILLS & CERTS
+            </span>
+          </div>
+          <div className="grid gap-3">
+            {data.talents.map((t) => {
+              const labels = TALENT_LABELS[t.key as TalentKey];
+              const Icon = TALENT_ICONS[t.key] ?? User;
+              return (
+                <div
+                  key={t.key}
+                  className="flex items-center justify-between rounded-2xl border border-primary/30 bg-primary/5 p-4 shadow-sm"
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="text-primary">
+                      <Icon className="h-6 w-6" />
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-semibold text-foreground">
+                        {labels?.label ?? t.key}
+                      </span>
+                      <span className="text-xs text-foreground/70">{labels?.subtitle}</span>
+                    </div>
+                  </div>
+                  <Check className="h-5 w-5 text-primary" />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Back link */}
+      <Link
+        href="/profiles"
+        className="text-center text-sm font-medium text-primary hover:underline"
+      >
+        ← Back to all members
+      </Link>
+    </div>
+  );
+}
+
+function InfoRow({
+  icon: Icon,
+  label,
+  value,
+  isLast = false,
+  isLink = false,
+  isEmpty = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  isLast?: boolean;
+  isLink?: boolean;
+  isEmpty?: boolean;
+}) {
+  return (
+    <div className={`p-4 ${!isLast ? "border-b border-border" : ""}`}>
+      <div className="flex items-center gap-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/5 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            {label}
+          </span>
+          {isLink && !isEmpty ? (
+            <a
+              href={value}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate text-sm font-medium text-primary hover:underline"
+            >
+              {value}
+            </a>
+          ) : (
+            <span
+              className={`truncate text-sm font-medium ${isEmpty ? "text-muted-foreground" : "text-foreground"}`}
+            >
+              {value}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/phone-input.tsx
+++ b/src/components/profile/phone-input.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+// Popular European countries for a German student organization
+const COUNTRY_CODES = [
+  { code: "+49", country: "DE", flag: "🇩🇪", name: "Germany" },
+  { code: "+43", country: "AT", flag: "🇦🇹", name: "Austria" },
+  { code: "+41", country: "CH", flag: "🇨🇭", name: "Switzerland" },
+  { code: "+33", country: "FR", flag: "🇫🇷", name: "France" },
+  { code: "+31", country: "NL", flag: "🇳🇱", name: "Netherlands" },
+  { code: "+32", country: "BE", flag: "🇧🇪", name: "Belgium" },
+  { code: "+39", country: "IT", flag: "🇮🇹", name: "Italy" },
+  { code: "+34", country: "ES", flag: "🇪🇸", name: "Spain" },
+  { code: "+44", country: "GB", flag: "🇬🇧", name: "United Kingdom" },
+  { code: "+48", country: "PL", flag: "🇵🇱", name: "Poland" },
+  { code: "+420", country: "CZ", flag: "🇨🇿", name: "Czech Republic" },
+  { code: "+1", country: "US", flag: "🇺🇸", name: "USA" },
+] as const;
+
+export type CountryCode = (typeof COUNTRY_CODES)[number]["code"];
+
+interface PhoneInputProps {
+  countryCode: CountryCode;
+  phoneNumber: string;
+  onCountryCodeChange: (code: CountryCode) => void;
+  onPhoneNumberChange: (number: string) => void;
+  error?: string;
+  className?: string;
+}
+
+export function PhoneInput({
+  countryCode,
+  phoneNumber,
+  onCountryCodeChange,
+  onPhoneNumberChange,
+  error,
+  className,
+}: PhoneInputProps) {
+  const selectedCountry = COUNTRY_CODES.find((c) => c.code === countryCode) ?? COUNTRY_CODES[0];
+
+  // Format phone number - strip non-digit characters except for display
+  const handlePhoneChange = (value: string) => {
+    // Allow digits, spaces, and dashes for formatting
+    const formatted = value.replace(/[^\d\s-]/g, "");
+    onPhoneNumberChange(formatted);
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <div className="flex gap-2">
+        <Select value={countryCode} onValueChange={(v) => onCountryCodeChange(v as CountryCode)}>
+          <SelectTrigger className="h-10 w-[100px] shrink-0 rounded-lg border-border bg-white">
+            <SelectValue>
+              <span className="flex items-center gap-1.5">
+                <span className="text-base">{selectedCountry.flag}</span>
+                <span className="text-sm font-medium">{selectedCountry.code}</span>
+              </span>
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent className="bg-white">
+            {COUNTRY_CODES.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                <span className="flex items-center gap-2">
+                  <span className="text-base">{country.flag}</span>
+                  <span className="text-sm">{country.code}</span>
+                  <span className="text-xs text-muted-foreground">{country.name}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <input
+          type="tel"
+          inputMode="tel"
+          value={phoneNumber}
+          onChange={(e) => handlePhoneChange(e.target.value)}
+          placeholder="170 1234567"
+          className={cn(
+            "h-10 flex-1 rounded-lg border bg-white px-3 text-sm font-medium outline-none transition-colors",
+            "placeholder:text-muted-foreground",
+            "focus:ring-2 focus:ring-ring focus:ring-offset-1",
+            error ? "border-destructive" : "border-border",
+          )}
+        />
+      </div>
+      {error && <span className="text-xs font-medium text-destructive">{error}</span>}
+    </div>
+  );
+}
+
+/**
+ * Parse a full phone string (e.g., "+49 170 1234567") into parts.
+ */
+export function parsePhoneNumber(full: string): { countryCode: CountryCode; number: string } {
+  if (!full) return { countryCode: "+49", number: "" };
+
+  // Try to match a country code at the start
+  for (const country of COUNTRY_CODES) {
+    if (full.startsWith(country.code)) {
+      return {
+        countryCode: country.code,
+        number: full.slice(country.code.length).trim(),
+      };
+    }
+  }
+
+  // Default to Germany if no match - preserve full input
+  return { countryCode: "+49", number: full.trim() };
+}
+
+/**
+ * Combine country code and number into a full phone string.
+ */
+export function formatFullPhoneNumber(countryCode: CountryCode, number: string): string {
+  if (!number.trim()) return "";
+  return `${countryCode} ${number.trim()}`;
+}

--- a/src/components/profile/profile-form.stories.tsx
+++ b/src/components/profile/profile-form.stories.tsx
@@ -1,0 +1,129 @@
+/**
+ * Stories for the ProfileForm component.
+ *
+ * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { trpcMutation, trpcQuery } from "../../../.storybook/utils/trpc-helpers";
+import { ProfileForm } from "./profile-form";
+
+const meta = {
+  title: "Profile/ProfileForm",
+  component: ProfileForm,
+  parameters: {
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ProfileForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock data for profile queries
+const mockUser = {
+  name: "Max Mustermann",
+  image: "https://i.pravatar.cc/96?u=max",
+};
+
+const mockProfile = {
+  userId: "user-1",
+  status: "active" as const,
+  division: "operations",
+  team: "concept", // Valid team for operations division
+  lastActiveYear: null,
+  teamOther: null,
+  phoneNumber: "+49 170 1234567",
+  privateEmail: "max@example.com",
+  linkedInUrl: "https://linkedin.com/in/maxmustermann",
+  isProfileComplete: true,
+  talentIds: ["driver_18plus", "gastro"],
+};
+
+const mockTalents = [
+  { id: "driver_18plus", category: "driver_license", key: "driver_18plus" },
+  { id: "driver_21plus", category: "driver_license", key: "driver_21plus" },
+  { id: "driver_c1", category: "driver_license", key: "driver_c1" },
+  { id: "gastro", category: "gastronomy", key: "gastro" },
+];
+
+/**
+ * Default view mode with existing profile data.
+ * Click "Edit Profile" to enter edit mode.
+ */
+export const ViewMode: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockProfile,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("profile", "update", () => ({ ok: true })),
+      ],
+    },
+  },
+};
+
+/**
+ * Empty profile state (new user).
+ */
+export const NewProfile: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: { name: "New User", image: null },
+          profile: null,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("profile", "update", () => ({ ok: true })),
+      ],
+    },
+  },
+};
+
+/**
+ * Alumni member with last active year.
+ */
+export const AlumniProfile: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: { name: "Former Member", image: "https://i.pravatar.cc/96?u=alumni" },
+          profile: {
+            ...mockProfile,
+            status: "alumni",
+            lastActiveYear: 2023,
+            talentIds: [],
+          },
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("profile", "update", () => ({ ok: true })),
+      ],
+    },
+  },
+};
+
+/**
+ * Loading state.
+ */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", async () => {
+          // Simulate slow network
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return { user: mockUser, profile: mockProfile };
+        }),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+      ],
+    },
+  },
+};

--- a/src/components/profile/profile-form.tsx
+++ b/src/components/profile/profile-form.tsx
@@ -1,0 +1,721 @@
+"use client";
+
+import { ErrorBanner } from "@/components/alerting/error-banner";
+import {
+  formatFullPhoneNumber,
+  parsePhoneNumber,
+  PhoneInput,
+  type CountryCode,
+} from "@/components/profile/phone-input";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  DIVISION_OPTIONS,
+  TALENT_LABELS,
+  TEAMS_BY_DIVISION,
+  type Division,
+  type Status,
+  type TalentKey,
+  type Team,
+} from "@/domain/qsum/profile";
+import { api } from "@/server/api/client";
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertCircle,
+  Car,
+  Check,
+  CheckCircle2,
+  Link as LinkIcon,
+  Mail,
+  Pencil,
+  Phone,
+  Save,
+  Truck,
+  User,
+  Utensils,
+  X,
+} from "lucide-react";
+import Image from "next/image";
+import * as React from "react";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Types
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface FormState {
+  status: Status;
+  division: Division | "";
+  team: Team | "";
+  lastActiveYear: string;
+  teamOther: string;
+  phoneCountryCode: CountryCode;
+  phoneNumber: string;
+  privateEmail: string;
+  linkedInUrl: string;
+  talentIds: string[];
+}
+
+interface FieldErrors {
+  phoneNumber?: string;
+  privateEmail?: string;
+  linkedInUrl?: string;
+}
+
+const INITIAL_STATE: FormState = {
+  status: "active",
+  division: "",
+  team: "",
+  lastActiveYear: "",
+  teamOther: "",
+  phoneCountryCode: "+49",
+  phoneNumber: "",
+  privateEmail: "",
+  linkedInUrl: "",
+  talentIds: [],
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Validation helpers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function validateLinkedInUrl(url: string): string | undefined {
+  if (!url.trim()) return undefined;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (host !== "linkedin.com" && host !== "www.linkedin.com" && !host.endsWith(".linkedin.com")) {
+      return "Please enter a valid LinkedIn URL (e.g., linkedin.com/in/yourname)";
+    }
+  } catch {
+    return "Please enter a valid URL";
+  }
+  return undefined;
+}
+
+function validateEmail(email: string): string | undefined {
+  if (!email.trim()) return undefined;
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return "Please enter a valid email address";
+  }
+  return undefined;
+}
+
+function validatePhoneNumber(number: string): string | undefined {
+  if (!number.trim()) return undefined;
+  const digitsOnly = number.replace(/\D/g, "");
+  if (digitsOnly.length < 6) return "Phone number is too short";
+  if (digitsOnly.length > 15) return "Phone number is too long";
+  return undefined;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const TALENT_ICONS: Record<TalentKey, LucideIcon> = {
+  driver_18plus: Car,
+  driver_21plus: Car,
+  driver_c1: Truck,
+  gastro: Utensils,
+};
+
+type ProfileData = Record<string, unknown>;
+
+function profileToFormState(p: ProfileData): FormState {
+  const storedPhone = (p.phoneNumber as string) ?? "";
+  const { countryCode, number } = parsePhoneNumber(storedPhone);
+  return {
+    status: (p.status as Status) ?? "active",
+    division: (p.division as Division) ?? "",
+    team: (p.team as Team) ?? "",
+    lastActiveYear: p.lastActiveYear != null ? String(p.lastActiveYear as number) : "",
+    teamOther: (p.teamOther as string) ?? "",
+    phoneCountryCode: countryCode,
+    phoneNumber: number,
+    privateEmail: (p.privateEmail as string) ?? "",
+    linkedInUrl: (p.linkedInUrl as string) ?? "",
+    talentIds: (p.talentIds as string[]) ?? [],
+  };
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Shared Sub-Components
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function ProfileHeader({
+  user,
+  profile,
+  divisionLabel,
+  teamLabel,
+  displayYear,
+}: {
+  user?: { name?: string | null; image?: string | null } | null;
+  profile: boolean;
+  divisionLabel: string | null;
+  teamLabel: string | null;
+  displayYear: string;
+}) {
+  return (
+    <div className="relative flex flex-col items-center rounded-2xl border border-border bg-white p-6 shadow-sm">
+      <div className="relative mb-4">
+        <div className="h-24 w-24 overflow-hidden rounded-full border-4 border-white bg-slate-200 shadow-sm">
+          {user?.image ? (
+            <Image
+              src={user.image}
+              alt={user.name ?? "Profile picture"}
+              width={96}
+              height={96}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-primary/10 text-primary">
+              <User className="h-10 w-10" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-1 flex items-center gap-2">
+        <h1 className="text-2xl font-bold text-foreground">{user?.name ?? "Member"}</h1>
+        {profile && (
+          <span className="flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700">
+            <CheckCircle2 className="h-3 w-3" />
+            Verified
+          </span>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {divisionLabel && teamLabel
+          ? `${divisionLabel} • ${teamLabel} • ${displayYear}`
+          : "Complete your profile below"}
+      </p>
+    </div>
+  );
+}
+
+function TalentCard({
+  talentKey,
+  isEnabled,
+  editable,
+  onToggle,
+}: {
+  talentKey: TalentKey;
+  isEnabled: boolean;
+  editable?: boolean;
+  onToggle?: () => void;
+}) {
+  const labels = TALENT_LABELS[talentKey];
+  const Icon = TALENT_ICONS[talentKey] ?? User;
+
+  return (
+    <div
+      className={`flex items-center justify-between rounded-2xl border p-4 shadow-sm ${
+        editable
+          ? "border-border bg-white"
+          : isEnabled
+            ? "border-primary/30 bg-primary/5"
+            : "border-border bg-white"
+      }`}
+    >
+      <div className="flex items-center gap-4">
+        <div className={editable || isEnabled ? "text-primary" : "text-muted-foreground/60"}>
+          <Icon className="h-6 w-6" />
+        </div>
+        <div className="flex flex-col">
+          <span
+            className={`text-sm font-semibold ${
+              editable || isEnabled ? "text-foreground" : "text-muted-foreground"
+            }`}
+          >
+            {labels.label}
+          </span>
+          <span className="text-xs text-foreground/70">{labels.subtitle}</span>
+        </div>
+      </div>
+      {editable ? (
+        <Switch checked={isEnabled} onCheckedChange={onToggle} />
+      ) : (
+        isEnabled && <Check className="h-5 w-5 text-primary" />
+      )}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function ProfileForm() {
+  const { data, isLoading } = api.profile.getMy.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const { data: talents = [] } = api.profile.listTalents.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const update = api.profile.update.useMutation();
+
+  const [form, setForm] = React.useState<FormState>(INITIAL_STATE);
+  const [errors, setErrors] = React.useState<FieldErrors>({});
+  const [isEditing, setIsEditing] = React.useState(false);
+  const hasInitialized = React.useRef(false);
+
+  const user = data?.user;
+  const profile = data?.profile;
+
+  React.useEffect(() => {
+    if (!profile || hasInitialized.current) return;
+    setForm(profileToFormState(profile as ProfileData));
+    hasInitialized.current = true;
+  }, [profile]);
+
+  // Derive display values
+  const divisionLabel = form.division
+    ? (DIVISION_OPTIONS.find((d) => d.value === form.division)?.label ?? null)
+    : null;
+  const teamLabel =
+    form.division && form.team
+      ? (TEAMS_BY_DIVISION[form.division]?.find((t) => t.value === form.team)?.label ?? null)
+      : null;
+  const displayYear = form.lastActiveYear || new Date().getFullYear().toString();
+  const showTeamOther = form.team === "other";
+
+  // Reset team when division changes
+  React.useEffect(() => {
+    setForm((prev) => {
+      if (!prev.division) {
+        if (!prev.team && !prev.teamOther) return prev;
+        return { ...prev, team: "", teamOther: "" };
+      }
+      const validOptions = TEAMS_BY_DIVISION[prev.division] ?? [];
+      if (!validOptions.some((opt) => opt.value === prev.team)) {
+        return { ...prev, team: "", teamOther: "" };
+      }
+      return prev;
+    });
+  }, [form.division]);
+
+  const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleTalent = (talentId: string) => {
+    setForm((prev) => ({
+      ...prev,
+      talentIds: prev.talentIds.includes(talentId)
+        ? prev.talentIds.filter((id) => id !== talentId)
+        : [...prev.talentIds, talentId],
+    }));
+  };
+
+  const onSubmit = () => {
+    if (!form.division || !form.team) return;
+
+    const fieldErrors: FieldErrors = {
+      phoneNumber: validatePhoneNumber(form.phoneNumber),
+      privateEmail: validateEmail(form.privateEmail),
+      linkedInUrl: validateLinkedInUrl(form.linkedInUrl),
+    };
+
+    const hasErrors = Object.values(fieldErrors).some(Boolean);
+    setErrors(fieldErrors);
+    if (hasErrors) return;
+
+    const fullPhoneNumber = formatFullPhoneNumber(form.phoneCountryCode, form.phoneNumber);
+
+    update.mutate(
+      {
+        status: form.status,
+        division: form.division,
+        team: form.team,
+        lastActiveYear: form.lastActiveYear ? parseInt(form.lastActiveYear, 10) : null,
+        teamOther: form.teamOther || null,
+        phoneNumber: fullPhoneNumber || null,
+        privateEmail: form.privateEmail || null,
+        linkedInUrl: form.linkedInUrl || null,
+        talentIds: form.talentIds,
+      },
+      {
+        onSuccess: () => setIsEditing(false),
+      },
+    );
+  };
+
+  const cancelEdit = () => {
+    if (profile) {
+      setForm(profileToFormState(profile as ProfileData));
+    }
+    setErrors({});
+    setIsEditing(false);
+  };
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-muted-foreground">Loading profile...</div>;
+  }
+
+  const displayPhone = formatFullPhoneNumber(form.phoneCountryCode, form.phoneNumber);
+  const canSubmit =
+    !!form.division &&
+    !!form.team &&
+    (!showTeamOther || form.teamOther.trim().length >= 2) &&
+    !update.isPending;
+
+  // ── View Mode ──────────────────────────────────────────────────────────
+  if (!isEditing) {
+    return (
+      <div className="grid gap-8">
+        <ProfileHeader
+          user={user}
+          profile={!!profile}
+          divisionLabel={divisionLabel}
+          teamLabel={teamLabel}
+          displayYear={displayYear}
+        />
+
+        {/* Personal Information */}
+        <div>
+          <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Personal Information</h2>
+          <div className="flex flex-col overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
+            <ViewRow
+              icon={Phone}
+              label="Phone Number"
+              value={displayPhone || "Not provided"}
+              isEmpty={!displayPhone}
+            />
+            <ViewRow
+              icon={Mail}
+              label="Private Email"
+              value={form.privateEmail || "Not provided"}
+              isEmpty={!form.privateEmail}
+            />
+            <ViewRow
+              icon={LinkIcon}
+              label="LinkedIn Profile"
+              value={form.linkedInUrl || "Not provided"}
+              isEmpty={!form.linkedInUrl}
+              isLast
+              isLink={!!form.linkedInUrl}
+            />
+          </div>
+        </div>
+
+        {/* Talents */}
+        <div>
+          <div className="mb-3 flex items-end justify-between px-1">
+            <h2 className="text-lg font-bold text-foreground">My Talents</h2>
+            <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+              SKILLS & CERTS
+            </span>
+          </div>
+          <div className="grid gap-3">
+            {talents.map((t) => (
+              <TalentCard
+                key={t.id}
+                talentKey={t.key as TalentKey}
+                isEnabled={form.talentIds.includes(t.id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Edit Button */}
+        <Button
+          onClick={() => setIsEditing(true)}
+          variant="default"
+          className="flex h-14 w-full items-center justify-center gap-2 rounded-xl text-lg font-semibold"
+        >
+          <Pencil className="h-5 w-5" />
+          Edit Profile
+        </Button>
+      </div>
+    );
+  }
+
+  // ── Edit Mode ──────────────────────────────────────────────────────────
+  return (
+    <div className="grid gap-8">
+      {update.error?.message && <ErrorBanner message={update.error.message} />}
+
+      <ProfileHeader
+        user={user}
+        profile={!!profile}
+        divisionLabel={divisionLabel}
+        teamLabel={teamLabel}
+        displayYear={displayYear}
+      />
+
+      {/* Membership Details */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Membership Details</h2>
+        <div className="grid gap-4">
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Board Area
+            </Label>
+            <Select
+              value={form.division}
+              onValueChange={(value) => updateField("division", value as Division)}
+            >
+              <SelectTrigger className="h-11 rounded-xl">
+                <SelectValue placeholder="Select your board area" />
+              </SelectTrigger>
+              <SelectContent className="bg-white">
+                {DIVISION_OPTIONS.map((d) => (
+                  <SelectItem key={d.value} value={d.value}>
+                    {d.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Team
+            </Label>
+            <Select
+              value={form.team}
+              onValueChange={(value) => {
+                const next = value as Team;
+                updateField("team", next);
+                if (next !== "other") updateField("teamOther", "");
+              }}
+              disabled={!form.division}
+            >
+              <SelectTrigger className="h-11 rounded-xl">
+                <SelectValue
+                  placeholder={form.division ? "Select your team" : "Select board area first"}
+                />
+              </SelectTrigger>
+              <SelectContent className="bg-white">
+                {form.division
+                  ? TEAMS_BY_DIVISION[form.division].map((team) => (
+                      <SelectItem key={team.value} value={team.value}>
+                        {team.label}
+                      </SelectItem>
+                    ))
+                  : null}
+              </SelectContent>
+            </Select>
+
+            {showTeamOther && (
+              <div className="pt-2">
+                <Label className="text-xs text-muted-foreground">Please specify your team</Label>
+                <Input
+                  className="mt-2 h-11 rounded-xl"
+                  value={form.teamOther}
+                  onChange={(e) => updateField("teamOther", e.target.value)}
+                  placeholder="e.g. Former team name"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Personal Information */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Personal Information</h2>
+        <div className="flex flex-col gap-4">
+          <div className="rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <span className="mb-2 block text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Phone Number
+            </span>
+            <PhoneInput
+              countryCode={form.phoneCountryCode}
+              phoneNumber={form.phoneNumber}
+              onCountryCodeChange={(code) => {
+                updateField("phoneCountryCode", code);
+                setErrors((prev) => ({ ...prev, phoneNumber: undefined }));
+              }}
+              onPhoneNumberChange={(num) => {
+                updateField("phoneNumber", num);
+                setErrors((prev) => ({ ...prev, phoneNumber: undefined }));
+              }}
+              error={errors.phoneNumber}
+            />
+          </div>
+
+          <div className="flex flex-col overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
+            <InfoRow
+              icon={Mail}
+              label="Private Email"
+              value={form.privateEmail}
+              onChange={(val) => {
+                updateField("privateEmail", val);
+                setErrors((prev) => ({ ...prev, privateEmail: undefined }));
+              }}
+              error={errors.privateEmail}
+            />
+            <InfoRow
+              icon={LinkIcon}
+              label="LinkedIn Profile"
+              value={form.linkedInUrl}
+              onChange={(val) => {
+                updateField("linkedInUrl", val);
+                setErrors((prev) => ({ ...prev, linkedInUrl: undefined }));
+              }}
+              error={errors.linkedInUrl}
+              isLast
+              isLink
+              placeholder="https://linkedin.com/in/yourname"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Talents */}
+      <div>
+        <div className="mb-3 flex items-end justify-between px-1">
+          <h2 className="text-lg font-bold text-foreground">My Talents</h2>
+          <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+            SKILLS & CERTS
+          </span>
+        </div>
+        <div className="grid gap-3">
+          {talents.map((t) => (
+            <TalentCard
+              key={t.id}
+              talentKey={t.key as TalentKey}
+              isEnabled={form.talentIds.includes(t.id)}
+              editable
+              onToggle={() => toggleTalent(t.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex gap-3">
+        <Button
+          onClick={cancelEdit}
+          variant="outline"
+          disabled={update.isPending}
+          className="flex h-14 flex-1 items-center justify-center gap-2 rounded-xl text-lg font-semibold"
+        >
+          <X className="h-5 w-5" />
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={!canSubmit}
+          className="flex h-14 flex-1 items-center justify-center gap-2 rounded-xl text-lg font-semibold shadow-md"
+        >
+          <Save className="h-5 w-5" />
+          {update.isPending ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Row Sub-Components
+ * ────────────────────────────────────────────────────────────────────────── */
+function InfoRow({
+  icon: Icon,
+  label,
+  value,
+  onChange,
+  error,
+  isLast = false,
+  isLink = false,
+  placeholder,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  onChange: (val: string) => void;
+  error?: string;
+  isLast?: boolean;
+  isLink?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <div className={`p-4 ${!isLast ? "border-b border-border" : ""}`}>
+      <div className="flex items-center gap-4">
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${error ? "bg-destructive/10 text-destructive" : "bg-primary/5 text-primary"}`}
+        >
+          {error ? <AlertCircle className="h-5 w-5" /> : <Icon className="h-5 w-5" />}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            {label}
+          </span>
+          <input
+            className={`w-full border-none bg-transparent p-0 text-sm font-medium focus:outline-none focus:ring-0 ${isLink ? "text-primary" : "text-foreground"}`}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder ?? `Enter ${label.toLowerCase()}`}
+          />
+        </div>
+        <Pencil className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
+      </div>
+      {error && (
+        <div className="ml-14 mt-2 flex items-center gap-1.5 text-xs font-medium text-destructive">
+          <AlertCircle className="h-3 w-3" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Helper component for view-only rows
+function ViewRow({
+  icon: Icon,
+  label,
+  value,
+  isLast = false,
+  isLink = false,
+  isEmpty = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  isLast?: boolean;
+  isLink?: boolean;
+  isEmpty?: boolean;
+}) {
+  return (
+    <div className={`p-4 ${!isLast ? "border-b border-border" : ""}`}>
+      <div className="flex items-center gap-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/5 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            {label}
+          </span>
+          {isLink && !isEmpty ? (
+            <a
+              href={value}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate text-sm font-medium text-primary hover:underline"
+            >
+              {value}
+            </a>
+          ) : (
+            <span
+              className={`truncate text-sm font-medium ${isEmpty ? "text-muted-foreground" : "text-foreground"}`}
+            >
+              {value}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/talent-picker.tsx
+++ b/src/components/profile/talent-picker.tsx
@@ -1,0 +1,72 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { TALENT_LABELS, type TalentKey } from "@/domain/qsum/profile";
+import { cn } from "@/lib/utils";
+
+const TALENT_CATEGORY_LABELS = {
+  driver_license: "Driver's Licenses",
+  gastronomy: "Gastronomy Experience",
+} as const;
+
+type TalentCategory = keyof typeof TALENT_CATEGORY_LABELS;
+
+interface Talent {
+  id: string;
+  category: TalentCategory;
+  key: string;
+}
+
+interface TalentPickerProps {
+  talents: Talent[];
+  selectedIds: string[];
+  onToggle: (talentId: string) => void;
+}
+
+export function TalentPicker({ talents, selectedIds, onToggle }: TalentPickerProps) {
+  const driverTalents = talents.filter((talent) => talent.category === "driver_license");
+  const gastronomyTalents = talents.filter((talent) => talent.category === "gastronomy");
+
+  const groups = [
+    {
+      category: "driver_license" as const,
+      label: TALENT_CATEGORY_LABELS.driver_license,
+      items: driverTalents,
+    },
+    {
+      category: "gastronomy" as const,
+      label: TALENT_CATEGORY_LABELS.gastronomy,
+      items: gastronomyTalents,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4">
+      {groups.map((group) => (
+        <div key={group.category} className="rounded-xl border border-border/80 p-4">
+          <div className="text-sm font-semibold text-foreground">{group.label}</div>
+          <div className="mt-3 grid gap-2">
+            {group.items.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No options available.</div>
+            ) : (
+              group.items.map((talent) => {
+                const isChecked = selectedIds.includes(talent.id);
+                const talentLabel = TALENT_LABELS[talent.key as TalentKey]?.label ?? talent.key;
+                return (
+                  <label
+                    key={talent.id}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border px-3 py-2 text-sm",
+                      isChecked ? "border-primary/40 bg-primary/5" : "border-transparent",
+                    )}
+                  >
+                    <Checkbox checked={isChecked} onCheckedChange={() => onToggle(talent.id)} />
+                    <span>{talentLabel}</span>
+                  </label>
+                );
+              })
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background text-primary",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3.5 w-3.5" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/domain/qsum/profile/constants.ts
+++ b/src/domain/qsum/profile/constants.ts
@@ -1,4 +1,4 @@
-import type { Division, LabeledValue, Status, Team } from "./types";
+import type { Division, LabeledValue, Status, TalentCategory, TalentKey, Team } from "./types";
 
 /* ──────────────────────────────────────────────────────────────────────────
  * Option Lists
@@ -49,4 +49,19 @@ export const TEAMS_BY_DIVISION: Record<Division, readonly LabeledValue<Team>[]> 
     { value: "gp", label: "G&P (Growth & Partnerships)" },
     { value: "other", label: "Other" },
   ],
+};
+
+export const TALENT_CATEGORY_LABELS: Record<TalentCategory, string> = {
+  driver_license: "Driver's Licenses",
+  gastronomy: "Gastronomy Experience",
+};
+
+export const TALENT_LABELS: Record<TalentKey, { label: string; subtitle: string }> = {
+  driver_18plus: { label: "18+", subtitle: "Driver's license, at least 18 years old" },
+  driver_21plus: {
+    label: "21+ (no probation)",
+    subtitle: "Driver's license, 21+ and out of probation period",
+  },
+  driver_c1: { label: "C1 License", subtitle: "Truck/transporter license (C1 or higher)" },
+  gastro: { label: "Gastro Experience", subtitle: "Experience in gastronomy/catering" },
 };

--- a/src/domain/qsum/profile/types.ts
+++ b/src/domain/qsum/profile/types.ts
@@ -21,6 +21,10 @@ export type Team =
   | "gp"
   | "other";
 
+export type TalentCategory = "driver_license" | "gastronomy";
+
+export type TalentKey = "driver_18plus" | "driver_21plus" | "driver_c1" | "gastro";
+
 /* ──────────────────────────────────────────────────────────────────────────
  * UI & Helper Interfaces
  * ────────────────────────────────────────────────────────────────────────── */
@@ -37,9 +41,18 @@ export interface LabeledValue<T extends string> {
 export interface MemberProfile {
   userId: string;
   status: Status;
-  lastActiveYear?: number;
+  lastActiveYear?: number | null;
   division: Division;
   team: Team;
-  teamOther?: string;
+  teamOther?: string | null;
+  phoneNumber?: string | null;
+  privateEmail?: string | null;
+  linkedInUrl?: string | null;
   isProfileComplete: boolean;
+}
+
+export interface Talent {
+  id: string;
+  category: TalentCategory;
+  key: TalentKey;
 }

--- a/src/domain/qsum/profile/validation.ts
+++ b/src/domain/qsum/profile/validation.ts
@@ -14,68 +14,110 @@ const divisionValues = DIVISION_OPTIONS.map((o) => o.value) as [Division, ...Div
  * Main Validation Schema
  * ────────────────────────────────────────────────────────────────────────── */
 
-export const ProfileUpdateSchema = z
-  .object({
-    status: z.enum(statusValues),
-    lastActiveYear: z.number().int().min(2016).max(2100).nullable(),
-    division: z.enum(divisionValues),
-    team: z.string(), // Validated against division in superRefine
-    teamOther: z.string().trim().min(2).max(80).nullable(),
-  })
-  .superRefine((val, ctx) => {
-    // 1. Alumni Logic: Must have a year
-    if (val.status === "alumni" && val.lastActiveYear == null) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["lastActiveYear"],
-        message: "Please provide the last year you were active.",
-      });
-    }
+// Base object schema (without refinements) - needed for .extend()
+const ProfileBaseSchema = z.object({
+  status: z.enum(statusValues),
+  lastActiveYear: z.number().int().min(2016).max(2100).nullable(),
+  division: z.enum(divisionValues),
+  team: z.string(), // Validated against division in superRefine
+  teamOther: z.string().trim().min(2).max(80).nullable(),
+});
 
-    // 2. Active Logic: Should not have a year
-    if (val.status === "active" && val.lastActiveYear != null) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["lastActiveYear"],
-        message: "Active members should not set a last active year.",
-      });
-    }
+// Shared refinement logic for profile validation
+type ProfileBaseInput = z.infer<typeof ProfileBaseSchema>;
+function refineProfile(val: ProfileBaseInput, ctx: z.RefinementCtx) {
+  // 1. Alumni Logic: Must have a year
+  if (val.status === "alumni" && val.lastActiveYear == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["lastActiveYear"],
+      message: "Please provide the last year you were active.",
+    });
+  }
 
-    // 3. Division/Team logic
-    // We cast to Division safely because Zod already checked division matches the enum above
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const allowedTeams = TEAMS_BY_DIVISION[val.division as Division].map((t) => t.value);
+  // 2. Active Logic: Should not have a year
+  if (val.status === "active" && val.lastActiveYear != null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["lastActiveYear"],
+      message: "Active members should not set a last active year.",
+    });
+  }
 
-    // Check if the string provided is actually a valid Team
-    if (val.team !== "other" && !allowedTeams.includes(val.team as Team)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["team"],
-        message: "Selected team does not belong to the chosen board area.",
-      });
-    }
+  // 3. Division/Team logic
+  // We cast to Division safely because Zod already checked division matches the enum above
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const allowedTeams = TEAMS_BY_DIVISION[val.division as Division].map((t) => t.value);
 
-    // 4. "Other" Logic
-    if (val.team === "other" && !val.teamOther) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["teamOther"],
-        message: "Please specify your team name.",
-      });
-    }
+  // Check if the string provided is actually a valid Team
+  if (val.team !== "other" && !allowedTeams.includes(val.team as Team)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["team"],
+      message: "Selected team does not belong to the chosen board area.",
+    });
+  }
 
-    // Cleanup: If team is NOT other, teamOther should be null (handled in mapping usually, but good to flag)
-    if (val.team !== "other" && val.teamOther) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["teamOther"],
-        message: "Only allowed when team is Other.",
-      });
-    }
-  });
+  // 4. "Other" Logic
+  if (val.team === "other" && !val.teamOther) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["teamOther"],
+      message: "Please specify your team name.",
+    });
+  }
+
+  // Cleanup: If team is NOT other, teamOther should be null (handled in mapping usually, but good to flag)
+  if (val.team !== "other" && val.teamOther) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["teamOther"],
+      message: "Only allowed when team is Other.",
+    });
+  }
+}
+
+export const ProfileUpdateSchema = ProfileBaseSchema.superRefine(refineProfile);
 
 // Export the inferred type for use in routers
 export type ProfileUpdateInput = z.infer<typeof ProfileUpdateSchema>;
+
+const phoneNumberSchema = z
+  .string()
+  .trim()
+  .min(6)
+  .max(40)
+  .regex(/^(?=.*\d)[+()\d\s.-]+$/);
+
+const linkedInUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(value);
+        const host = url.hostname.toLowerCase();
+        return (
+          host === "linkedin.com" || host === "www.linkedin.com" || host.endsWith(".linkedin.com")
+        );
+      } catch {
+        return false;
+      }
+    },
+    {
+      message: "LinkedIn URL must be on linkedin.com",
+    },
+  );
+
+export const ProfileEditSchema = ProfileBaseSchema.extend({
+  phoneNumber: phoneNumberSchema.nullable(),
+  privateEmail: z.string().trim().email().nullable(),
+  linkedInUrl: linkedInUrlSchema.nullable(),
+  talentIds: z.array(z.string().min(1)),
+}).superRefine(refineProfile);
+
+export type ProfileEditInput = z.infer<typeof ProfileEditSchema>;
 
 /**
  * Helper to clean up data before sending to DB.
@@ -92,6 +134,21 @@ export function normalizeProfileInput(userId: string, input: ProfileUpdateInput)
     // Ensure data consistency
     teamOther: input.team === "other" ? input.teamOther : null,
     lastActiveYear: input.status === "alumni" ? input.lastActiveYear : null,
+    isProfileComplete: true,
+  } as const;
+}
+
+export function normalizeProfileEditInput(userId: string, input: ProfileEditInput) {
+  return {
+    userId,
+    status: input.status,
+    division: input.division,
+    team: input.team as Team,
+    teamOther: input.team === "other" ? input.teamOther : null,
+    lastActiveYear: input.status === "alumni" ? input.lastActiveYear : null,
+    phoneNumber: input.phoneNumber ? input.phoneNumber.trim() : null,
+    privateEmail: input.privateEmail ? input.privateEmail.trim() : null,
+    linkedInUrl: input.linkedInUrl ? input.linkedInUrl.trim() : null,
     isProfileComplete: true,
   } as const;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,3 +26,32 @@ export function safeDecodeURIComponent(value: string): string | null {
     return null;
   }
 }
+
+/**
+ * Resolve a callbackUrl from searchParams, with safe decoding and validation.
+ * Returns the fallback path if the callback is invalid or missing.
+ */
+export function resolveCallbackUrl(
+  rawCallbackUrl: string | undefined,
+  fallback = "/dashboard",
+): string {
+  if (!rawCallbackUrl) return fallback;
+
+  const decoded = safeDecodeURIComponent(rawCallbackUrl);
+  if (decoded && isValidRedirectPath(decoded)) {
+    return decoded;
+  }
+
+  return fallback;
+}
+
+/**
+ * Build a /login URL that preserves the intended destination.
+ * Used in server components when redirecting unauthenticated users.
+ */
+export function buildLoginRedirect(currentPath: string): string {
+  if (isValidRedirectPath(currentPath)) {
+    return `/login?callbackUrl=${encodeURIComponent(currentPath)}`;
+  }
+  return "/login";
+}

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -1,15 +1,51 @@
-import { ProfileUpdateSchema, normalizeProfileInput } from "@/domain/qsum/profile";
+/**
+ * Profile router - handles member profile CRUD and talent management.
+ */
+import {
+  ProfileEditSchema,
+  ProfileUpdateSchema,
+  normalizeProfileEditInput,
+  normalizeProfileInput,
+} from "@/domain/qsum/profile";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
-import { memberProfile } from "@/server/db/schema";
-import { eq } from "drizzle-orm";
+import { memberProfile, talent, user, userTalent } from "@/server/db/schema";
+import { TRPCError } from "@trpc/server";
+import { and, count, eq, inArray, like, sql } from "drizzle-orm";
+import { z } from "zod";
 
 export const profileRouter = createTRPCRouter({
   getMy: protectedProcedure.query(async ({ ctx }) => {
-    return (
-      (await ctx.db.query.memberProfile.findFirst({
-        where: eq(memberProfile.userId, ctx.session.user.id),
-      })) ?? null
-    );
+    const userId = ctx.session.user.id;
+    const { name, image } = ctx.session.user;
+
+    const profile = await ctx.db.query.memberProfile.findFirst({
+      where: eq(memberProfile.userId, userId),
+    });
+
+    if (!profile) {
+      return { user: { name, image }, profile: null };
+    }
+
+    const talentRows: { talentId: string }[] = await ctx.db
+      .select({ talentId: userTalent.talentId })
+      .from(userTalent)
+      .where(eq(userTalent.userId, userId));
+
+    return {
+      user: { name, image },
+      profile: {
+        ...profile,
+        talentIds: talentRows.map((row) => row.talentId),
+      },
+    };
+  }),
+
+  listTalents: protectedProcedure.query(async ({ ctx }) => {
+    const talents: { id: string; category: string; key: string }[] = await ctx.db
+      .select({ id: talent.id, category: talent.category, key: talent.key })
+      .from(talent)
+      .orderBy(talent.category, talent.key);
+    return talents;
   }),
 
   complete: protectedProcedure.input(ProfileUpdateSchema).mutation(async ({ ctx, input }) => {
@@ -25,4 +61,144 @@ export const profileRouter = createTRPCRouter({
 
     return { ok: true };
   }),
+
+  update: protectedProcedure.input(ProfileEditSchema).mutation(async ({ ctx, input }) => {
+    const userId = ctx.session.user.id;
+    const typedInput = input;
+    const dbValues = normalizeProfileEditInput(userId, typedInput);
+
+    await ctx.db.transaction(async (tx) => {
+      await tx.insert(memberProfile).values(dbValues).onConflictDoUpdate({
+        target: memberProfile.userId,
+        set: dbValues,
+      });
+
+      if (typedInput.talentIds.length) {
+        const validTalents: { id: string }[] = await tx
+          .select({ id: talent.id })
+          .from(talent)
+          .where(inArray(talent.id, typedInput.talentIds));
+
+        if (validTalents.length !== typedInput.talentIds.length) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "One or more talents are invalid.",
+          });
+        }
+      }
+
+      const existingTalents: { talentId: string }[] = await tx
+        .select({ talentId: userTalent.talentId })
+        .from(userTalent)
+        .where(eq(userTalent.userId, userId));
+
+      const existingIds = existingTalents.map((row) => row.talentId);
+      const existingSet = new Set(existingIds);
+      const nextSet = new Set(typedInput.talentIds);
+
+      const toAdd = typedInput.talentIds.filter((id: string) => !existingSet.has(id));
+      const toRemove = existingIds.filter((id) => !nextSet.has(id));
+
+      if (toRemove.length) {
+        await tx
+          .delete(userTalent)
+          .where(and(eq(userTalent.userId, userId), inArray(userTalent.talentId, toRemove)));
+      }
+
+      if (toAdd.length) {
+        await tx.insert(userTalent).values(toAdd.map((talentId: string) => ({ userId, talentId })));
+      }
+    });
+
+    return { ok: true };
+  }),
+
+  getByUserId: protectedProcedure
+    .input(z.object({ userId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const rows = await ctx.db
+        .select({
+          name: user.name,
+          image: user.image,
+          status: memberProfile.status,
+          division: memberProfile.division,
+          team: memberProfile.team,
+          teamOther: memberProfile.teamOther,
+          lastActiveYear: memberProfile.lastActiveYear,
+          phoneNumber: memberProfile.phoneNumber,
+          privateEmail: memberProfile.privateEmail,
+          linkedInUrl: memberProfile.linkedInUrl,
+        })
+        .from(user)
+        .innerJoin(memberProfile, eq(memberProfile.userId, user.id))
+        .where(eq(user.id, input.userId))
+        .limit(1);
+
+      const profile = rows[0];
+      if (!profile) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Profile not found." });
+      }
+
+      const talentRows = await ctx.db
+        .select({ key: talent.key, category: talent.category })
+        .from(userTalent)
+        .innerJoin(talent, eq(talent.id, userTalent.talentId))
+        .where(eq(userTalent.userId, input.userId));
+
+      return { ...profile, talents: talentRows };
+    }),
+
+  list: protectedProcedure
+    .input(
+      z.object({
+        cursor: z.number().int().nonnegative().default(0),
+        limit: z.number().int().min(1).max(50).default(20),
+        search: z.string().max(100).default(""),
+        division: z.string().max(50).optional(),
+        team: z.string().max(50).optional(),
+        year: z.number().int().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { cursor, limit, search, division, team, year } = input;
+
+      const conditions = [];
+      if (search) conditions.push(like(user.name, `%${search}%`));
+      if (division) conditions.push(sql`${memberProfile.division} = ${division}`);
+      if (team) conditions.push(sql`${memberProfile.team} = ${team}`);
+      if (year) conditions.push(eq(memberProfile.lastActiveYear, year));
+      const baseWhere = conditions.length ? and(...conditions) : undefined;
+
+      const [totalResult, rows] = await Promise.all([
+        ctx.db
+          .select({ value: count() })
+          .from(user)
+          .innerJoin(memberProfile, eq(memberProfile.userId, user.id))
+          .where(baseWhere),
+        ctx.db
+          .select({
+            id: user.id,
+            name: user.name,
+            image: user.image,
+            division: memberProfile.division,
+            team: memberProfile.team,
+            status: memberProfile.status,
+            lastActiveYear: memberProfile.lastActiveYear,
+          })
+          .from(user)
+          .innerJoin(memberProfile, eq(memberProfile.userId, user.id))
+          .where(baseWhere)
+          .orderBy(user.name)
+          .limit(limit)
+          .offset(cursor),
+      ]);
+
+      const total = totalResult[0]?.value ?? 0;
+
+      return {
+        items: rows,
+        total,
+        nextCursor: cursor + limit < total ? cursor + limit : null,
+      };
+    }),
 });

--- a/src/server/db/_migrations/0002_profile_talents.sql
+++ b/src/server/db/_migrations/0002_profile_talents.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+ALTER TABLE `member_profile` ADD COLUMN `phoneNumber` text;--> statement-breakpoint
+ALTER TABLE `member_profile` ADD COLUMN `privateEmail` text;--> statement-breakpoint
+ALTER TABLE `member_profile` ADD COLUMN `linkedInUrl` text;--> statement-breakpoint
+CREATE TABLE `talent` (
+  `id` text PRIMARY KEY NOT NULL,
+  `category` text NOT NULL,
+  `key` text NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `talent_key_unique` ON `talent` (`key`);--> statement-breakpoint
+CREATE TABLE `user_talent` (
+  `userId` text NOT NULL,
+  `talentId` text NOT NULL,
+  PRIMARY KEY (`userId`, `talentId`),
+  FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`talentId`) REFERENCES `talent`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `talent` (`id`, `category`, `key`) VALUES
+  ('driver_18plus', 'driver_license', 'driver_18plus'),
+  ('driver_21plus', 'driver_license', 'driver_21plus'),
+  ('driver_c1', 'driver_license', 'driver_c1'),
+  ('gastro', 'gastronomy', 'gastro');--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/src/server/db/_migrations/meta/0002_snapshot.json
+++ b/src/server/db/_migrations/meta/0002_snapshot.json
@@ -1,0 +1,501 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f3c8e1b5-3c5b-4e66-9d12-3cdb8c3f7b21",
+  "prevId": "86bc391b-1451-4f7c-95fb-ec18c9d5d594",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member_profile": {
+      "name": "member_profile",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastActiveYear": {
+          "name": "lastActiveYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamOther": {
+          "name": "teamOther",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "privateEmail": {
+          "name": "privateEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkedInUrl": {
+          "name": "linkedInUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isProfileComplete": {
+          "name": "isProfileComplete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_profile_userId_user_id_fk": {
+          "name": "member_profile_userId_user_id_fk",
+          "tableFrom": "member_profile",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talent": {
+      "name": "talent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talent_key_unique": {
+          "name": "talent_key_unique",
+          "columns": ["key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_talent": {
+      "name": "user_talent",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "talentId": {
+          "name": "talentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_talent_userId_user_id_fk": {
+          "name": "user_talent_userId_user_id_fk",
+          "tableFrom": "user_talent",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_talent_talentId_talent_id_fk": {
+          "name": "user_talent_talentId_talent_id_fk",
+          "tableFrom": "user_talent",
+          "tableTo": "talent",
+          "columnsFrom": ["talentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_talent_userId_talentId_pk": {
+          "name": "user_talent_userId_talentId_pk",
+          "columns": ["userId", "talentId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  }
+}

--- a/src/server/db/_migrations/meta/_journal.json
+++ b/src/server/db/_migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1770379145234,
       "tag": "0001_awesome_tomas",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1772145600000,
+      "tag": "0002_profile_talents",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 /**
  * ──────────────────────────────────────────────────────────────────────────────
@@ -128,5 +128,30 @@ export const memberProfile = sqliteTable("member_profile", {
 
   teamOther: text("teamOther"),
 
+  phoneNumber: text("phoneNumber"),
+  privateEmail: text("privateEmail"),
+  linkedInUrl: text("linkedInUrl"),
+
   isProfileComplete: integer("isProfileComplete", { mode: "boolean" }).notNull().default(false),
 });
+
+export const talent = sqliteTable("talent", {
+  id: text("id").primaryKey(),
+  category: text("category", { enum: ["driver_license", "gastronomy"] }).notNull(),
+  key: text("key").notNull().unique(),
+});
+
+export const userTalent = sqliteTable(
+  "user_talent",
+  {
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    talentId: text("talentId")
+      .notNull()
+      .references(() => talent.id, { onDelete: "cascade" }),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.talentId] }),
+  }),
+);


### PR DESCRIPTION
## Summary

Closes #6 

<details>
<summary>Recording of new functions</summary>

https://github.com/user-attachments/assets/b6efdf01-51d5-41e3-974e-d0cbc51af70d

</details>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a mobile-friendly Edit Profile and member directory with phone/email/LinkedIn and talent management, plus new APIs, validation, and DB changes. Closes #6.

- **New Features**
  - Edit Profile (/profile): Phone input with country code; validation for phone/private email/LinkedIn; save via profile.update; optional callbackUrl.
  - Member directory (/profiles) and profile viewer (/profile/[id]): Search, filters (division/team/year), pagination; read-only view for others.
  - API: getMy returns user (name/image) and profile with talentIds; listTalents; listMembers with search/filter/pagination; toggle talents stored in user_talent; getByUserId for profile viewer.
  - Mobile layout & auth: AppHeader/AppFooter with active nav; pages for /dashboard, /shifts, /profiles, /profile; auth guard via buildLoginRedirect; home redirects to post-auth → dashboard.
  - Auth & utils: buildLoginRedirect and resolveCallbackUrl on complete-profile and post-auth; Next.js Images allow Google avatars; added Radix Switch/Checkbox; Storybook defaults to iPhone 13 Pro with page/layout stories.

- **Migration**
  - Run 0002_profile_talents.
    - member_profile: +phoneNumber, +privateEmail, +linkedInUrl (nullable).
    - New tables: talent (seeded), user_talent (composite PK, cascades).
  - No breaking changes; existing profiles remain valid.

<sup>Written for commit 6942b1e5008898b7912570ac0cc24882ba9f1752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





