### PR TITLE
feat(shifts): volunteer shift planning system for Q-Summit 2026

### DIFF
--- a/.ada/data/pr-resolver/pr-14/actionable.json
+++ b/.ada/data/pr-resolver/pr-14/actionable.json
@@ -1,0 +1,233 @@
+{
+  "pr_number": 14,
+  "repository": "Q-Summit/q-portal",
+  "generated_at": "2026-03-17T20:57:31Z",
+  "note": "Token-efficient output: only actionable clusters (unresolved_count > 0). Use data.json for full historical context.",
+  "statistics": {
+    "total_comments": 82,
+    "resolved_comments": 62,
+    "unresolved_comments": 20,
+    "actionable_clusters": 9
+  },
+  "clusters": [
+    {
+      "cluster_id": "sisyphus-plans-shift-planning-md-security",
+      "file": ".sisyphus/plans/shift-planning.md",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147162",
+          "path": ".sisyphus/plans/shift-planning.md",
+          "line": 824,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 824:\n\n<comment>Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.</comment>\n\n<file context>\n@@ -0,0 +1,1014 @@\n+\n+**What to do**:\n+\n+- Add plannerProcedure to create/update/delete\n+- Hide create button for non-planners\n+- Show edit/delete only for planners\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/22ff8753-e537-45ea-baae-630225272a43\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147162",
+          "thread_id": "PRRT_kwDOQS2Asc50-L52",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "sisyphus-plans-shift-planning-md-suggestion",
+      "file": ".sisyphus/plans/shift-planning.md",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147201",
+          "path": ".sisyphus/plans/shift-planning.md",
+          "line": 690,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 690:\n\n<comment>The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.</comment>\n\n<file context>\n@@ -0,0 +1,1014 @@\n+\n+- Create calendar component:\n+  - Day selector (April 9, April 10)\n+  - Y-axis: 30-min time slots (06:00-23:00)\n+  - X-axis: Locations OR just show total per slot\n+  - Cell shows headcount number\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/77bf3b3d-60fc-4023-bbbf-eca713b878a8\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147201",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6Y",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-app-mobile-shifts-page-tsx-security",
+      "file": "src/app/(mobile)/shifts/page.tsx",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949480919",
+          "path": "src/app/(mobile)/shifts/page.tsx",
+          "line": 27,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP2: Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 27:\n\n<comment>Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.</comment>\n\n<file context>\n@@ -12,6 +15,21 @@ export default async function ShiftsPage() {\n+  ]);\n+\n+  const isHeadOf = userRow[0]?.isHeadOf ?? false;\n+  const isPlanner = profile?.division === \"chair\" || isHeadOf;\n+\n+  if (!isPlanner) {\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/90fb693f-e792-4f68-9d26-2f32c4fb73e2\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480919",
+          "thread_id": "PRRT_kwDOQS2Asc50_JtR",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-app-mobile-shifts-shifts-page-stories-tsx-suggestion",
+      "file": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147193",
+          "path": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+          "line": 301,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: These \"CalendarView\" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 300:\n\n<comment>These \"CalendarView\" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.</comment>\n\n<file context>\n@@ -1,128 +1,349 @@\n+/**\n+ * Calendar view - showing shifts by time slots.\n+ */\n+export const CalendarView: Story = {\n+  parameters: {\n+    msw: {\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/b547a2b6-2b8c-42e3-9e08-736af6f76d6e\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147193",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6Q",
+          "resolved": false
+        },
+        {
+          "id": "2949147284",
+          "path": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+          "line": 278,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP3: Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 263:\n\n<comment>Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.</comment>\n\n<file context>\n@@ -1,128 +1,349 @@\n+/**\n+ * Loading state - while fetching data.\n+ */\n+export const ListViewLoading: Story = {\n+  parameters: {\n+    msw: {\n</file context>\n```\n\n</details>\n\n```suggestion\nexport const ListViewLoading: Story = {\n  parameters: {\n    msw: {\n      handlers: [\n        trpcQuery(\"profile\", \"getMy\", async () => {\n          await new Promise((resolve) => setTimeout(resolve, 100000));\n          return {\n            user: mockUser,\n            profile: mockRegularProfile,\n          };\n        }),\n        trpcQuery(\"shift\", \"list\", async () => {\n          await new Promise((resolve) => setTimeout(resolve, 100000));\n          return {\n            items: [],\n            total: 0,\n            nextCursor: null,\n          };\n        }),\n      ],\n    },\n  },\n};\n```\n\n<a href=\"https://www.cubic.dev/action/fix/violation/fe755a28-2a23-4916-b388-cc627941f16b\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147284",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7d",
+          "resolved": false
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 0,
+      "unresolved_count": 2,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-components-shifts-calendar-view-stories-tsx-suggestion",
+      "file": "src/components/shifts/calendar-view.stories.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949232734",
+          "path": "src/components/shifts/calendar-view.stories.tsx",
+          "line": 829,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.stories.tsx, line 829:\n\n<comment>The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.</comment>\n\n<file context>\n@@ -822,9 +822,14 @@ export const Interactive: Story = {\n+    const cells = canvasElement.querySelectorAll('[class*=\"cursor-pointer\"]');\n+    const shiftCells = Array.from(cells).filter((cell) => {\n+      const className = cell.className || '';\n+      return className.includes('bg-primary') || className.includes('bg-');\n+    });\n+    if (shiftCells.length > 0) {\n</file context>\n```\n\n</details>\n\n```suggestion\n      return className.includes('bg-primary');\n```\n\n<a href=\"https://www.cubic.dev/action/fix/violation/8dcbca12-3c1b-494a-85e1-788c48a67b0f\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949232734",
+          "thread_id": "PRRT_kwDOQS2Asc50-bUE",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-components-shifts-csv-export-button-tsx-import-fix",
+      "file": "src/components/shifts/csv-export-button.tsx",
+      "concern": "import-fix",
+      "comments": [
+        {
+          "id": "2949159013",
+          "path": "src/components/shifts/csv-export-button.tsx",
+          "line": 10,
+          "author": "Copilot",
+          "body": "`React` is imported but never used in this file, which will trigger the repo's unused-vars warning. Remove the `import * as React from \"react\";` line.",
+          "category": "import-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159013",
+          "thread_id": "PRRT_kwDOQS2Asc50-OHh",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-domain-qsum-shifts-validation-ts-issue",
+      "file": "src/domain/qsum/shifts/validation.ts",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949480924",
+          "path": "src/domain/qsum/shifts/validation.ts",
+          "line": 119,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/validation.ts, line 119:\n\n<comment>Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.</comment>\n\n<file context>\n@@ -87,20 +103,25 @@ export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;\n-    description: input.description?.trim() ?? null,\n-    notionLink: input.notionLink?.trim() ?? null,\n+    description: blankToNull(input.description),\n+    notionLink: blankToNull(input.notionLink),\n     startTime: input.startTime,\n     endTime: input.endTime,\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/1a0e54c7-91f2-4112-ba25-3c3d82a35003\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480924",
+          "thread_id": "PRRT_kwDOQS2Asc50_JtW",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-server-api-routers-shift-ts-suggestion",
+      "file": "src/server/api/routers/shift.ts",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949480938",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 526,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/api/routers/shift.ts, line 526:\n\n<comment>Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.</comment>\n\n<file context>\n@@ -522,8 +523,7 @@ export const shiftRouter = createTRPCRouter({\n \n-    // UTF-8 BOM for German Excel compatibility\n-    const csv = \"\\uFEFF\" + rows.join(\"\\n\");\n+    const csv = rows.join(\"\\n\");\n     return { csv };\n   }),\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/640d8279-4968-4ae4-b3cd-2d5c5bd4670d\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480938",
+          "thread_id": "PRRT_kwDOQS2Asc50_Jti",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-server-db-migrations-0003-little-sandman-sql-suggestion",
+      "file": "src/server/db/_migrations/0003_little_sandman.sql",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147190",
+          "path": "src/server/db/_migrations/0003_little_sandman.sql",
+          "line": 17,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/db/_migrations/0003_little_sandman.sql, line 17:\n\n<comment>Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.</comment>\n\n<file context>\n@@ -0,0 +1,40 @@\n+\tFOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade\n+);\n+--> statement-breakpoint\n+CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);--> statement-breakpoint\n+CREATE TABLE `shift_tools` (\n+\t`id` text PRIMARY KEY NOT NULL,\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/974d55cc-0d1e-4429-a6d1-b8a51b8514ca\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147190",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6O",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    }
+  ]
+}

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-csv-format-md-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-csv-format-md-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: docs-shifts-csv-format-md-suggestion
+
+## Context
+
+| Property   | Value                           |
+| ---------- | ------------------------------- |
+| PR         | #14                             |
+| Repository | Q-Summit/q-portal               |
+| File       | `.docs/shifts/csv-format.md`    |
+| Concern    | suggestion                      |
+| Status     | true (1 unresolved, 0 resolved) |
+
+## Comments
+
+### Comment 2949147260 [UNRESOLVED]
+
+- **Line**: 191
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147260
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7I
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: The Node.js example does not actually parse the documented CSV format; splitting on `\n` and `;` breaks valid quoted fields with semicolons or newlines.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/csv-format.md, line 191:
+
+<comment>The Node.js example does not actually parse the documented CSV format; splitting on `\n` and `;` breaks valid quoted fields with semicolons or newlines.</comment>
+
+<file context>
+@@ -0,0 +1,240 @@
++const headers = lines[0].split(";");
++
++const data = lines.slice(1).map((line) => {
++  const values = line.split(";");
++  return headers.reduce((obj, header, i) => {
++    obj[header] = values[i];
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/a1d40206-6c5e-4426-9ae2-6ebb538d4fca" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-csv-format-md-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-csv-format-md-uncategorized.md
@@ -1,0 +1,75 @@
+# Cluster: docs-shifts-csv-format-md-uncategorized
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `.docs/shifts/csv-format.md`     |
+| Concern    | uncategorized                    |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147260 [RESOLVED]
+
+- **Line**: 191
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147260
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7I
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: The Node.js example does not actually parse the documented CSV format; splitting on `\n` and `;` breaks valid quoted fields with semicolons or newlines.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/csv-format.md, line 191:
+
+<comment>The Node.js example does not actually parse the documented CSV format; splitting on `\n` and `;` breaks valid quoted fields with semicolons or newlines.</comment>
+
+<file context>
+@@ -0,0 +1,240 @@
++const headers = lines[0].split(";");
++
++const data = lines.slice(1).map((line) => {
++  const values = line.split(";");
++  return headers.reduce((obj, header, i) => {
++    obj[header] = values[i];
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-readme-md-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-readme-md-security.md
@@ -1,0 +1,73 @@
+# Cluster: docs-shifts-readme-md-security
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `.docs/shifts/README.md`         |
+| Concern    | security                         |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147214 [RESOLVED]
+
+- **Line**: 71
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147214
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6i
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: This related-docs link points to a non-existent file, leaving the new auth reference unusable.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/README.md, line 71:
+
+<comment>This related-docs link points to a non-existent file, leaving the new auth reference unusable.</comment>
+
+<file context>
+@@ -0,0 +1,71 @@
++
++- [Development Setup](../guides/dev-setup.md) - Local development instructions
++- [Database Schema](../db/schema.md) - Full database documentation
++- [API Authentication](../api/authentication.md) - Auth flows and procedures
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-role-access-md-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-role-access-md-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: docs-shifts-role-access-md-suggestion
+
+## Context
+
+| Property   | Value                           |
+| ---------- | ------------------------------- |
+| PR         | #14                             |
+| Repository | Q-Summit/q-portal               |
+| File       | `.docs/shifts/role-access.md`   |
+| Concern    | suggestion                      |
+| Status     | true (1 unresolved, 0 resolved) |
+
+## Comments
+
+### Comment 2949147158 [UNRESOLVED]
+
+- **Line**: 36
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147158
+- **Thread ID**: PRRT_kwDOQS2Asc50-L5z
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":7} -->
+P1: Documenting planner access as `division === "chair"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/role-access.md, line 36:
+
+<comment>Documenting planner access as `division === "chair"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.</comment>
+
+<file context>
+@@ -0,0 +1,285 @@
++A user is considered a **planner** if:
++
++1. They are logged in (authenticated)
++2. Their profile has `division === "chair"`
++
++This includes:
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/fdab4637-bc98-48fa-a58e-87f66177d624" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-role-access-md-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-role-access-md-uncategorized.md
@@ -1,0 +1,75 @@
+# Cluster: docs-shifts-role-access-md-uncategorized
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `.docs/shifts/role-access.md`    |
+| Concern    | uncategorized                    |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147158 [RESOLVED]
+
+- **Line**: 36
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147158
+- **Thread ID**: PRRT_kwDOQS2Asc50-L5z
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":7} -->
+P1: Documenting planner access as `division === "chair"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/role-access.md, line 36:
+
+<comment>Documenting planner access as `division === "chair"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.</comment>
+
+<file context>
+@@ -0,0 +1,285 @@
++A user is considered a **planner** if:
++
++1. They are logged in (authenticated)
++2. Their profile has `division === "chair"`
++
++This includes:
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-workflow-md-import-fix.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/docs-shifts-workflow-md-import-fix.md
@@ -1,0 +1,79 @@
+# Cluster: docs-shifts-workflow-md-import-fix
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `.docs/shifts/workflow.md`       |
+| Concern    | import-fix                       |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147263 [RESOLVED]
+
+- **Line**: 7
+- **Author**: cubic-dev-ai[bot]
+- **Category**: import-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147263
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7K
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: The prerequisite documents the wrong access-control field. Planner access is described elsewhere as `isHeadOf`-based, so telling users to require `division = "chair"` will mislead Board users and admins.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/workflow.md, line 7:
+
+<comment>The prerequisite documents the wrong access-control field. Planner access is described elsewhere as `isHeadOf`-based, so telling users to require `division = "chair"` will mislead Board users and admins.</comment>
+
+<file context>
+@@ -0,0 +1,192 @@
++
++## Prerequisites
++
++- You must be logged in with a Chair or Board role (division = "chair")
++- Access the shift planning page via the main navigation
++
+</file context>
+````
+
+</details>
+
+```suggestion
+- You must be logged in with planner access (`isHeadOf = true`, used for Chair/Board members)
+```
+
+✅ Addressed in [`211ca78`](https://github.com/Q-Summit/q-portal/commit/211ca782045f967d2d1115eb252a5b193e13246d)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/sisyphus-plans-shift-planning-md-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/sisyphus-plans-shift-planning-md-security.md
@@ -1,0 +1,81 @@
+# Cluster: sisyphus-plans-shift-planning-md-security
+
+## Context
+
+| Property   | Value                               |
+| ---------- | ----------------------------------- |
+| PR         | #14                                 |
+| Repository | Q-Summit/q-portal                   |
+| File       | `.sisyphus/plans/shift-planning.md` |
+| Concern    | security                            |
+| Status     | true (1 unresolved, 0 resolved)     |
+
+## Comments
+
+### Comment 2949147162 [UNRESOLVED]
+
+- **Line**: 824
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147162
+- **Thread ID**: PRRT_kwDOQS2Asc50-L52
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P1: Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 824:
+
+<comment>Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.</comment>
+
+<file context>
+@@ -0,0 +1,1014 @@
++
++**What to do**:
++
++- Add plannerProcedure to create/update/delete
++- Hide create button for non-planners
++- Show edit/delete only for planners
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/22ff8753-e537-45ea-baae-630225272a43" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/sisyphus-plans-shift-planning-md-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/sisyphus-plans-shift-planning-md-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: sisyphus-plans-shift-planning-md-suggestion
+
+## Context
+
+| Property   | Value                               |
+| ---------- | ----------------------------------- |
+| PR         | #14                                 |
+| Repository | Q-Summit/q-portal                   |
+| File       | `.sisyphus/plans/shift-planning.md` |
+| Concern    | suggestion                          |
+| Status     | true (1 unresolved, 0 resolved)     |
+
+## Comments
+
+### Comment 2949147201 [UNRESOLVED]
+
+- **Line**: 690
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147201
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6Y
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 690:
+
+<comment>The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.</comment>
+
+<file context>
+@@ -0,0 +1,1014 @@
++
++- Create calendar component:
++  - Day selector (April 9, April 10)
++  - Y-axis: 30-min time slots (06:00-23:00)
++  - X-axis: Locations OR just show total per slot
++  - Cell shows headcount number
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/77bf3b3d-60fc-4023-bbbf-eca713b878a8" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-security.md
@@ -1,0 +1,81 @@
+# Cluster: src-app-mobile-shifts-page-tsx-security
+
+## Context
+
+| Property   | Value                              |
+| ---------- | ---------------------------------- |
+| PR         | #14                                |
+| Repository | Q-Summit/q-portal                  |
+| File       | `src/app/(mobile)/shifts/page.tsx` |
+| Concern    | security                           |
+| Status     | true (1 unresolved, 0 resolved)    |
+
+## Comments
+
+### Comment 2949480919 [UNRESOLVED]
+
+- **Line**: 27
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480919
+- **Thread ID**: PRRT_kwDOQS2Asc50_JtR
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P2: Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 27:
+
+<comment>Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.</comment>
+
+<file context>
+@@ -12,6 +15,21 @@ export default async function ShiftsPage() {
++  ]);
++
++  const isHeadOf = userRow[0]?.isHeadOf ?? false;
++  const isPlanner = profile?.division === "chair" || isHeadOf;
++
++  if (!isPlanner) {
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/90fb693f-e792-4f68-9d26-2f32c4fb73e2" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: src-app-mobile-shifts-page-tsx-suggestion
+
+## Context
+
+| Property   | Value                              |
+| ---------- | ---------------------------------- |
+| PR         | #14                                |
+| Repository | Q-Summit/q-portal                  |
+| File       | `src/app/(mobile)/shifts/page.tsx` |
+| Concern    | suggestion                         |
+| Status     | true (1 unresolved, 0 resolved)    |
+
+## Comments
+
+### Comment 2949147153 [UNRESOLVED]
+
+- **Line**: 17
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147153
+- **Thread ID**: PRRT_kwDOQS2Asc50-L5u
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P1: This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 17:
+
+<comment>This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.</comment>
+
+<file context>
+@@ -13,9 +14,7 @@ export default async function ShiftsPage() {
+-      <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
+-      <p className="mt-2 text-muted-foreground">Your upcoming shifts will appear here.</p>
+-      {/* TODO: Shifts list */}
++      <ShiftManager />
+     </div>
+   );
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/f6084d13-39fe-4804-9a20-c3f9667ed684" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-page-tsx-uncategorized.md
@@ -1,0 +1,75 @@
+# Cluster: src-app-mobile-shifts-page-tsx-uncategorized
+
+## Context
+
+| Property   | Value                              |
+| ---------- | ---------------------------------- |
+| PR         | #14                                |
+| Repository | Q-Summit/q-portal                  |
+| File       | `src/app/(mobile)/shifts/page.tsx` |
+| Concern    | uncategorized                      |
+| Status     | false (0 unresolved, 1 resolved)   |
+
+## Comments
+
+### Comment 2949147153 [RESOLVED]
+
+- **Line**: 35
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147153
+- **Thread ID**: PRRT_kwDOQS2Asc50-L5u
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P1: This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 17:
+
+<comment>This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.</comment>
+
+<file context>
+@@ -13,9 +14,7 @@ export default async function ShiftsPage() {
+-      <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
+-      <p className="mt-2 text-muted-foreground">Your upcoming shifts will appear here.</p>
+-      {/* TODO: Shifts list */}
++      <ShiftManager />
+     </div>
+   );
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-shifts-page-stories-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-app-mobile-shifts-shifts-page-stories-tsx-suggestion.md
@@ -1,0 +1,154 @@
+# Cluster: src-app-mobile-shifts-shifts-page-stories-tsx-suggestion
+
+## Context
+
+| Property   | Value                                             |
+| ---------- | ------------------------------------------------- |
+| PR         | #14                                               |
+| Repository | Q-Summit/q-portal                                 |
+| File       | `src/app/(mobile)/shifts/shifts-page.stories.tsx` |
+| Concern    | suggestion                                        |
+| Status     | true (2 unresolved, 0 resolved)                   |
+
+## Comments
+
+### Comment 2949147193 [UNRESOLVED]
+
+- **Line**: 301
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147193
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6Q
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: These "CalendarView" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 300:
+
+<comment>These "CalendarView" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.</comment>
+
+<file context>
+@@ -1,128 +1,349 @@
++/**
++ * Calendar view - showing shifts by time slots.
++ */
++export const CalendarView: Story = {
++  parameters: {
++    msw: {
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/b547a2b6-2b8c-42e3-9e08-736af6f76d6e" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+### Comment 2949147284 [UNRESOLVED]
+
+- **Line**: 278
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147284
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7d
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P3: Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 263:
+
+<comment>Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.</comment>
+
+<file context>
+@@ -1,128 +1,349 @@
++/**
++ * Loading state - while fetching data.
++ */
++export const ListViewLoading: Story = {
++  parameters: {
++    msw: {
+</file context>
+````
+
+</details>
+
+```suggestion
+export const ListViewLoading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return {
+            user: mockUser,
+            profile: mockRegularProfile,
+          };
+        }),
+        trpcQuery("shift", "list", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return {
+            items: [],
+            total: 0,
+            nextCursor: null,
+          };
+        }),
+      ],
+    },
+  },
+};
+```
+
+<a href="https://www.cubic.dev/action/fix/violation/fe755a28-2a23-4916-b388-cc627941f16b" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 2 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-stories-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-stories-tsx-suggestion.md
@@ -1,0 +1,85 @@
+# Cluster: src-components-shifts-calendar-view-stories-tsx-suggestion
+
+## Context
+
+| Property   | Value                                             |
+| ---------- | ------------------------------------------------- |
+| PR         | #14                                               |
+| Repository | Q-Summit/q-portal                                 |
+| File       | `src/components/shifts/calendar-view.stories.tsx` |
+| Concern    | suggestion                                        |
+| Status     | true (1 unresolved, 0 resolved)                   |
+
+## Comments
+
+### Comment 2949232734 [UNRESOLVED]
+
+- **Line**: 829
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949232734
+- **Thread ID**: PRRT_kwDOQS2Asc50-bUE
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.stories.tsx, line 829:
+
+<comment>The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.</comment>
+
+<file context>
+@@ -822,9 +822,14 @@ export const Interactive: Story = {
++    const cells = canvasElement.querySelectorAll('[class*="cursor-pointer"]');
++    const shiftCells = Array.from(cells).filter((cell) => {
++      const className = cell.className || '';
++      return className.includes('bg-primary') || className.includes('bg-');
++    });
++    if (shiftCells.length > 0) {
+</file context>
+````
+
+</details>
+
+```suggestion
+      return className.includes('bg-primary');
+```
+
+<a href="https://www.cubic.dev/action/fix/violation/8dcbca12-3c1b-494a-85e1-788c48a67b0f" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-issue.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-calendar-view-tsx-issue
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/calendar-view.tsx` |
+| Concern    | issue                                     |
+| Status     | false (0 unresolved, 2 resolved)          |
+
+## Comments
+
+### Comment 2949159228 [RESOLVED]
+
+- **Line**: 217
+- **Author**: Copilot
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159228
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKV
+
+**Body**:
+
+```
+The modal close button is icon-only and missing an accessible name. Add `aria-label="Close"` (or `sr-only` text) so assistive tech can identify the control.
+```
+
+---
+
+### Comment 2949524521 [RESOLVED]
+
+- **Line**: 217
+- **Author**: LukasStrickler
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524521
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKV
+
+**Body**:
+
+```
+Dismissed: Fixed: Added aria-label='Close' to modal close button in commit 211ca78
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-suggestion.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-calendar-view-tsx-suggestion
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/calendar-view.tsx` |
+| Concern    | suggestion                                |
+| Status     | false (0 unresolved, 2 resolved)          |
+
+## Comments
+
+### Comment 2949159264 [RESOLVED]
+
+- **Line**: 467
+- **Author**: Copilot
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159264
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKu
+
+**Body**:
+
+```
+The calendar cell click targets are `<div>` elements with `onClick` but no keyboard interaction support. Prefer a `<button>` for each cell (or add role/tabIndex/key handlers) so users can navigate and activate cells via keyboard.
+```
+
+---
+
+### Comment 2949524573 [RESOLVED]
+
+- **Line**: 467
+- **Author**: LukasStrickler
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524573
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKu
+
+**Body**:
+
+```
+Dismissed: Fixed: Added role='button', tabIndex, and onKeyDown handler to grid cells in commit 211ca78
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-calendar-view-tsx-uncategorized.md
@@ -1,0 +1,195 @@
+# Cluster: src-components-shifts-calendar-view-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/calendar-view.tsx` |
+| Concern    | uncategorized                             |
+| Status     | false (0 unresolved, 6 resolved)          |
+
+## Comments
+
+### Comment 2949147172 [RESOLVED]
+
+- **Line**: 96
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147172
+- **Thread ID**: PRRT_kwDOQS2Asc50-L5-
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P1: The calendar rows are hard-coded to April 9, so switching to April 10 makes all slot lookups miss and the second day renders empty.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.tsx, line 96:
+
+<comment>The calendar rows are hard-coded to April 9, so switching to April 10 makes all slot lookups miss and the second day renders empty.</comment>
+
+<file context>
+@@ -0,0 +1,511 @@
++/** Generate all 30-min time slots from START_HOUR to END_HOUR */
++function generateTimeSlots(): Date[] {
++  const slots: Date[] = [];
++  const baseDate = new Date(2026, 3, 9); // Use April 9 as base
++
++  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949147228 [RESOLVED]
+
+- **Line**: 126
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147228
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6u
+
+**Body**:
+
+```
+
+<!-- metadata:{"confidence":9} -->
+
+P2: Sum all matching shifts for a cell instead of showing only the first shift's headcount.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.tsx, line 126:
+
+<comment>Sum all matching shifts for a cell instead of showing only the first shift's headcount.</comment>
+
+<file context>
+@@ -0,0 +1,511 @@
++  const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
++  if (!slot) return 0;
++
++  const shift = slot.shifts.find((sh) => sh.location === location);
++  return shift?.headcount ?? 0;
++}
+</file context>
+```
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949159211 [RESOLVED]
+
+- **Line**: 127
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159211
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKH
+
+**Body**:
+
+```
+
+`getHeadcountForSlot` only returns the first shift’s headcount for a given location/time, but there can be multiple shifts at the same location in the same slot. Sum the headcount across all matching shifts so the badge shows the correct total.
+
+```
+
+---
+
+### Comment 2949159247 [RESOLVED]
+
+- **Line**: 446
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159247
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKh
+
+**Body**:
+
+```
+
+Interactive grid cells are implemented as `<div onClick=...>`, which are not keyboard-accessible by default. Use semantic buttons/links, or add `role="button"`, `tabIndex={0}`, and key handlers (Enter/Space) to meet keyboard accessibility requirements.
+
+```
+
+---
+
+### Comment 2949524516 [RESOLVED]
+
+- **Line**: 446
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524516
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKh
+
+**Body**:
+
+```
+
+Dismissed: Fixed: Added keyboard accessibility to interactive grid cells in commit 211ca78
+
+```
+
+---
+
+### Comment 2949528437 [RESOLVED]
+
+- **Line**: 127
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528437
+- **Thread ID**: PRRT_kwDOQS2Asc50-OKH
+
+**Body**:
+
+```
+
+Dismissed: Fixed: getHeadcountForSlot now sums all matching shifts instead of returning first in commit 018cd1f
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-stories-tsx-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-stories-tsx-issue.md
@@ -1,0 +1,75 @@
+# Cluster: src-components-shifts-csv-export-button-stories-tsx-issue
+
+## Context
+
+| Property   | Value                                                 |
+| ---------- | ----------------------------------------------------- |
+| PR         | #14                                                   |
+| Repository | Q-Summit/q-portal                                     |
+| File       | `src/components/shifts/csv-export-button.stories.tsx` |
+| Concern    | issue                                                 |
+| Status     | false (0 unresolved, 1 resolved)                      |
+
+## Comments
+
+### Comment 2949147221 [RESOLVED]
+
+- **Line**: 112
+- **Author**: cubic-dev-ai[bot]
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147221
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6o
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: Match the MSW handler to `/api/trpc/shift.exportCsv`; the current route never intercepts this mutation, so the error story won't render the failure state.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/csv-export-button.stories.tsx, line 112:
+
+<comment>Match the MSW handler to `/api/trpc/shift.exportCsv`; the current route never intercepts this mutation, so the error story won't render the failure state.</comment>
+
+<file context>
+@@ -0,0 +1,164 @@
++  parameters: {
++    msw: {
++      handlers: [
++        http.post("*/api/trpc", async ({ request }) => {
++          const body = (await request.json()) as { json?: { params?: { path?: string } } };
++          const path = body?.json?.params?.path;
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-tsx-import-fix.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-tsx-import-fix.md
@@ -1,0 +1,51 @@
+# Cluster: src-components-shifts-csv-export-button-tsx-import-fix
+
+## Context
+
+| Property   | Value                                         |
+| ---------- | --------------------------------------------- |
+| PR         | #14                                           |
+| Repository | Q-Summit/q-portal                             |
+| File       | `src/components/shifts/csv-export-button.tsx` |
+| Concern    | import-fix                                    |
+| Status     | true (1 unresolved, 0 resolved)               |
+
+## Comments
+
+### Comment 2949159013 [UNRESOLVED]
+
+- **Line**: 10
+- **Author**: Copilot
+- **Category**: import-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159013
+- **Thread ID**: PRRT_kwDOQS2Asc50-OHh
+
+**Body**:
+
+```
+`React` is imported but never used in this file, which will trigger the repo's unused-vars warning. Remove the `import * as React from "react";` line.
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-csv-export-button-tsx-uncategorized.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-csv-export-button-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                         |
+| ---------- | --------------------------------------------- |
+| PR         | #14                                           |
+| Repository | Q-Summit/q-portal                             |
+| File       | `src/components/shifts/csv-export-button.tsx` |
+| Concern    | uncategorized                                 |
+| Status     | false (0 unresolved, 2 resolved)              |
+
+## Comments
+
+### Comment 2949158993 [RESOLVED]
+
+- **Line**: 17
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158993
+- **Thread ID**: PRRT_kwDOQS2Asc50-OHN
+
+**Body**:
+
+```
+`CsvExportButton` prepends a UTF-8 BOM to `data.csv`, but the server's `shift.exportCsv` response already includes a BOM. This will result in a double BOM in the downloaded file. Decide on a single source of truth (server or client) and remove the duplicate BOM addition.
+```
+
+---
+
+### Comment 2949524558 [RESOLVED]
+
+- **Line**: 17
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524558
+- **Thread ID**: PRRT_kwDOQS2Asc50-OHN
+
+**Body**:
+
+```
+Dismissed: Fixed: Client no longer adds BOM - server already includes it. Comment updated in code.
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-form-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-form-tsx-suggestion.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-form-tsx-suggestion
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-form.tsx` |
+| Concern    | suggestion                             |
+| Status     | false (0 unresolved, 2 resolved)       |
+
+## Comments
+
+### Comment 2949159099 [RESOLVED]
+
+- **Line**: 232
+- **Author**: Copilot
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159099
+- **Thread ID**: PRRT_kwDOQS2Asc50-OIs
+
+**Body**:
+
+```
+The `Label` components aren’t associated with their corresponding inputs (no `htmlFor` / matching `id`, and the label doesn't wrap the input). This hurts screen reader support. Add `id` on inputs and `htmlFor` on labels (or wrap the input with the label).
+```
+
+---
+
+### Comment 2949524501 [RESOLVED]
+
+- **Line**: 232
+- **Author**: LukasStrickler
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524501
+- **Thread ID**: PRRT_kwDOQS2Asc50-OIs
+
+**Body**:
+
+```
+Dismissed: Fixed: Associated labels with inputs via htmlFor/id and added fieldset/legend for groups in commit 211ca78
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-form-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-form-tsx-uncategorized.md
@@ -1,0 +1,119 @@
+# Cluster: src-components-shifts-shift-form-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-form.tsx` |
+| Concern    | uncategorized                          |
+| Status     | false (0 unresolved, 2 resolved)       |
+
+## Comments
+
+### Comment 2949147171 [RESOLVED]
+
+- **Line**: 168
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147171
+- **Thread ID**: PRRT_kwDOQS2Asc50-L59
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P1: This create payload omits `slots`, so new shifts are always created with 0 headcount in every slot.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-form.tsx, line 154:
+
+<comment>This create payload omits `slots`, so new shifts are always created with 0 headcount in every slot.</comment>
+
+<file context>
+@@ -0,0 +1,428 @@
++        startTime: new Date(form.startTime),
++        endTime: new Date(form.endTime),
++        skillIds: form.skillIds,
++        tools: form.tools,
++      },
++      {
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949147224 [RESOLVED]
+
+- **Line**: 283
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147224
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6q
+
+**Body**:
+
+```
+
+<!-- metadata:{"confidence":9} -->
+
+P2: Constrain both datetime inputs to 30-minute increments or the API will reject many submissions.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-form.tsx, line 257:
+
+<comment>Constrain both datetime inputs to 30-minute increments or the API will reject many submissions.</comment>
+
+<file context>
+@@ -0,0 +1,428 @@
++            <div className="flex items-center gap-3">
++              <Calendar className="h-5 w-5 text-muted-foreground" />
++              <Input
++                type="datetime-local"
++                aria-label="Start time"
++                className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+</file context>
+```
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-stories-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-stories-tsx-uncategorized.md
@@ -1,0 +1,113 @@
+# Cluster: src-components-shifts-shift-list-stories-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                          |
+| ---------- | ---------------------------------------------- |
+| PR         | #14                                            |
+| Repository | Q-Summit/q-portal                              |
+| File       | `src/components/shifts/shift-list.stories.tsx` |
+| Concern    | uncategorized                                  |
+| Status     | false (0 unresolved, 3 resolved)               |
+
+## Comments
+
+### Comment 2949147244 [RESOLVED]
+
+- **Line**: 245
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147244
+- **Thread ID**: PRRT_kwDOQS2Asc50-L68
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: The `play` function targets selectors that never exist, so this story silently skips the edit interaction.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.stories.tsx, line 245:
+
+<comment>The `play` function targets selectors that never exist, so this story silently skips the edit interaction.</comment>
+
+<file context>
+@@ -0,0 +1,338 @@
++
++    // Find and click the edit button on the first row
++    const editButton =
++      canvasElement.querySelector('[data-testid="edit-shift-1"]') ??
++      canvasElement.querySelector('button[title="Edit"]');
++
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949159285 [RESOLVED]
+
+- **Line**: 247
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159285
+- **Thread ID**: PRRT_kwDOQS2Asc50-OK_
+
+**Body**:
+
+```
+
+`InlineEditing` story tries to find an edit button via `[data-testid="edit-shift-1"]` or `button[title="Edit"]`, but the `ShiftList` component doesn’t render either attribute. The play function will likely do nothing. Add stable attributes to the component (e.g. `aria-label` or `data-testid`) and update the selector accordingly.
+
+```
+
+---
+
+### Comment 2949528409 [RESOLVED]
+
+- **Line**: 247
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528409
+- **Thread ID**: PRRT_kwDOQS2Asc50-OK_
+
+**Body**:
+
+```
+
+Dismissed: Fixed: Added data-testid attributes to edit/delete buttons for story testing in commit 018cd1f
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-issue.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-list-tsx-issue
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-list.tsx` |
+| Concern    | issue                                  |
+| Status     | false (0 unresolved, 2 resolved)       |
+
+## Comments
+
+### Comment 2949159167 [RESOLVED]
+
+- **Line**: 321
+- **Author**: Copilot
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159167
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJi
+
+**Body**:
+
+```
+The save/cancel buttons in the inline edit row are icon-only and missing accessible names. Add `aria-label`/`sr-only` text so screen readers can announce “Save” and “Cancel”.
+```
+
+---
+
+### Comment 2949524510 [RESOLVED]
+
+- **Line**: 321
+- **Author**: LukasStrickler
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524510
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJi
+
+**Body**:
+
+```
+Dismissed: Fixed: Updated save/cancel button aria-labels in commit 211ca78
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-suggestion.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-list-tsx-suggestion
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-list.tsx` |
+| Concern    | suggestion                             |
+| Status     | false (0 unresolved, 2 resolved)       |
+
+## Comments
+
+### Comment 2949159191 [RESOLVED]
+
+- **Line**: 406
+- **Author**: Copilot
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159191
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJ0
+
+**Body**:
+
+```
+`slotSummary.totalHeadcount === 0` is rendered as "No slots", but it really means the total required headcount is 0. This is misleading if slots exist but are unstaffed. Consider renaming the label or returning slot count separately.
+```
+
+---
+
+### Comment 2949528468 [RESOLVED]
+
+- **Line**: 406
+- **Author**: LukasStrickler
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528468
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJ0
+
+**Body**:
+
+```
+Dismissed: Acknowledged: Label 'No slots' indicates 0 total headcount - intentional design choice for clarity
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-type-fix.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-type-fix.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-list-tsx-type-fix
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-list.tsx` |
+| Concern    | type-fix                               |
+| Status     | false (0 unresolved, 2 resolved)       |
+
+## Comments
+
+### Comment 2949159120 [RESOLVED]
+
+- **Line**: 341
+- **Author**: Copilot
+- **Category**: type-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159120
+- **Thread ID**: PRRT_kwDOQS2Asc50-OI5
+
+**Body**:
+
+```
+`ShiftRowProps` is declared twice in the same file. TypeScript will merge these declarations, which can unintentionally change required/optional props and make the type harder to reason about. Consolidate into a single `ShiftRowProps` definition.
+```
+
+---
+
+### Comment 2949524584 [RESOLVED]
+
+- **Line**: 341
+- **Author**: LukasStrickler
+- **Category**: type-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524584
+- **Thread ID**: PRRT_kwDOQS2Asc50-OI5
+
+**Body**:
+
+```
+Dismissed: Verified: Only one ShiftRowProps declaration exists in the file - no duplicate to consolidate
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-list-tsx-uncategorized.md
@@ -1,0 +1,195 @@
+# Cluster: src-components-shifts-shift-list-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/components/shifts/shift-list.tsx` |
+| Concern    | uncategorized                          |
+| Status     | false (0 unresolved, 6 resolved)       |
+
+## Comments
+
+### Comment 2949147238 [RESOLVED]
+
+- **Line**: 231
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147238
+- **Thread ID**: PRRT_kwDOQS2Asc50-L63
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: Render the Actions `<td>` only for planners. Non-planner rows currently have an extra body cell that does not match the header columns.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.tsx, line 245:
+
+<comment>Render the Actions `<td>` only for planners. Non-planner rows currently have an extra body cell that does not match the header columns.</comment>
+
+<file context>
+@@ -0,0 +1,544 @@
++
++  return (
++    <tr className="bg-accent/30">
++      <td className="px-4 py-3">
++        <div className="space-y-1">
++          <div className="flex items-center gap-2">
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949147242 [RESOLVED]
+
+- **Line**: 315
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147242
+- **Thread ID**: PRRT_kwDOQS2Asc50-L66
+
+**Body**:
+
+```
+
+<!-- metadata:{"confidence":9} -->
+
+P2: Pass the shift's real `skillIds` into `SkillsBadge`. As written, the Skills column always renders empty for every shift.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.tsx, line 315:
+
+<comment>Pass the shift's real `skillIds` into `SkillsBadge`. As written, the Skills column always renders empty for every shift.</comment>
+
+<file context>
+@@ -0,0 +1,544 @@
++        )}
++      </td>
++      <td className="px-4 py-3">
++        <SkillsBadge skillIds={[]} talents={talents} />
++      </td>
++      <td className="px-4 py-3">
+</file context>
+```
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949159134 [RESOLVED]
+
+- **Line**: 415
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159134
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJH
+
+**Body**:
+
+```
+
+The skills column always renders an empty skills list (`skillIds={[]}`), so the UI will never show required skills even if they exist. Either remove the skills column from `ShiftList`, or extend the data model/API to include `skillIds` (or a summary) in the list items and pass the real values to `SkillsBadge`.
+
+```
+
+---
+
+### Comment 2949159150 [RESOLVED]
+
+- **Line**: 428
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159150
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJW
+
+**Body**:
+
+```
+
+The action buttons are icon-only but have no accessible name. Add `aria-label` (or an `sr-only` span) to the edit/delete buttons so they are usable with screen readers.
+
+```
+
+---
+
+### Comment 2949524507 [RESOLVED]
+
+- **Line**: 428
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524507
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJW
+
+**Body**:
+
+```
+
+Dismissed: Already fixed: Edit/delete buttons already have aria-labels (Edit shift/Delete shift)
+
+```
+
+---
+
+### Comment 2949528431 [RESOLVED]
+
+- **Line**: 415
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528431
+- **Thread ID**: PRRT_kwDOQS2Asc50-OJH
+
+**Body**:
+
+```
+
+Dismissed: Fixed: Skills column now passes shift.skillIds to SkillsBadge in commit 018cd1f
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-import-fix.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-import-fix.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-manager-tsx-import-fix
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/shift-manager.tsx` |
+| Concern    | import-fix                                |
+| Status     | false (0 unresolved, 2 resolved)          |
+
+## Comments
+
+### Comment 2949158885 [RESOLVED]
+
+- **Line**: 16
+- **Author**: Copilot
+- **Category**: import-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158885
+- **Thread ID**: PRRT_kwDOQS2Asc50-OFy
+
+**Body**:
+
+```
+`AlertCircle` is imported but never used, which will trigger the repo's `@typescript-eslint/no-unused-vars` warning. Remove the import or use it in the component.
+```
+
+---
+
+### Comment 2949524524 [RESOLVED]
+
+- **Line**: 16
+- **Author**: LukasStrickler
+- **Category**: import-fix
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524524
+- **Thread ID**: PRRT_kwDOQS2Asc50-OFy
+
+**Body**:
+
+```
+Dismissed: Verified: AlertCircle is not imported - only AlertTriangle is used
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-issue.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-manager-tsx-issue
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/shift-manager.tsx` |
+| Concern    | issue                                     |
+| Status     | false (0 unresolved, 2 resolved)          |
+
+## Comments
+
+### Comment 2949158966 [RESOLVED]
+
+- **Line**: 190
+- **Author**: Copilot
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158966
+- **Thread ID**: PRRT_kwDOQS2Asc50-OG2
+
+**Body**:
+
+```
+`navigateDay` allows moving to dates outside the API's allowed Q-Summit dates (Apr 9/10 2026), which will cause `shift.calendar` to error. Consider constraining navigation to the allowed date set (similar to `src/components/shifts/calendar-view.tsx`) or disabling prev/next when out of range.
+```
+
+---
+
+### Comment 2949524489 [RESOLVED]
+
+- **Line**: 190
+- **Author**: LukasStrickler
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524489
+- **Thread ID**: PRRT_kwDOQS2Asc50-OG2
+
+**Body**:
+
+```
+Dismissed: Verified: navigateDay already constrains to Q-Summit dates via QSUMMIT_DATES array
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-security.md
@@ -1,0 +1,75 @@
+# Cluster: src-components-shifts-shift-manager-tsx-security
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/shift-manager.tsx` |
+| Concern    | security                                  |
+| Status     | false (0 unresolved, 1 resolved)          |
+
+## Comments
+
+### Comment 2949147255 [RESOLVED]
+
+- **Line**: 311
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147255
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7F
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: Use the planner flag here instead of `division === "chair"`; this hides create/export actions from authorized Board users.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-manager.tsx, line 311:
+
+<comment>Use the planner flag here instead of `division === "chair"`; this hides create/export actions from authorized Board users.</comment>
+
+<file context>
+@@ -0,0 +1,453 @@
++    refetchOnWindowFocus: false,
++  });
++
++  const isPlanner = profileData?.profile?.division === "chair";
++
++  // Fetch shifts list
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-suggestion.md
@@ -1,0 +1,68 @@
+# Cluster: src-components-shifts-shift-manager-tsx-suggestion
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/shift-manager.tsx` |
+| Concern    | suggestion                                |
+| Status     | false (0 unresolved, 2 resolved)          |
+
+## Comments
+
+### Comment 2949158943 [RESOLVED]
+
+- **Line**: 137
+- **Author**: Copilot
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158943
+- **Thread ID**: PRRT_kwDOQS2Asc50-OGi
+
+**Body**:
+
+```
+`slotSummary.totalHeadcount === 0` is being rendered as "No slots", but a shift can have slots with zero headcount. Consider changing the label (e.g. "0 volunteers"/"Unstaffed") or returning an explicit slot count from the API if you truly want to detect “no slots”.
+```
+
+---
+
+### Comment 2949528435 [RESOLVED]
+
+- **Line**: 137
+- **Author**: LukasStrickler
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528435
+- **Thread ID**: PRRT_kwDOQS2Asc50-OGi
+
+**Body**:
+
+```
+Dismissed: Acknowledged: Label 'No slots' indicates 0 total headcount - intentional design choice
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-components-shifts-shift-manager-tsx-uncategorized.md
@@ -1,0 +1,113 @@
+# Cluster: src-components-shifts-shift-manager-tsx-uncategorized
+
+## Context
+
+| Property   | Value                                     |
+| ---------- | ----------------------------------------- |
+| PR         | #14                                       |
+| Repository | Q-Summit/q-portal                         |
+| File       | `src/components/shifts/shift-manager.tsx` |
+| Concern    | uncategorized                             |
+| Status     | false (0 unresolved, 3 resolved)          |
+
+## Comments
+
+### Comment 2949147295 [RESOLVED]
+
+- **Line**: 197
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147295
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7m
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P3: Render the year from `selectedDate`; the hard-coded `2026` becomes wrong once the user navigates outside that year.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-manager.tsx, line 197:
+
+<comment>Render the year from `selectedDate`; the hard-coded `2026` becomes wrong once the user navigates outside that year.</comment>
+
+<file context>
+@@ -0,0 +1,453 @@
++              day: "numeric",
++            })}
++          </div>
++          <div className="text-xs text-muted-foreground">2026</div>
++        </div>
++        <Button variant="ghost" size="icon" onClick={() => navigateDay("next")} className="h-9 w-9">
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949158923 [RESOLVED]
+
+- **Line**: 237
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158923
+- **Thread ID**: PRRT_kwDOQS2Asc50-OGS
+
+**Body**:
+
+```
+
+The calendar navigation buttons are icon-only and currently have no accessible name. Add `aria-label` (or an `sr-only` label) to both the previous/next day buttons so screen readers can announce their purpose.
+
+```
+
+---
+
+### Comment 2949524514 [RESOLVED]
+
+- **Line**: 237
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524514
+- **Thread ID**: PRRT_kwDOQS2Asc50-OGS
+
+**Body**:
+
+```
+
+Dismissed: Verified: Navigation buttons already have aria-labels (Previous day/Next day)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-constants-ts-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-constants-ts-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: src-domain-qsum-shifts-constants-ts-suggestion
+
+## Context
+
+| Property   | Value                                 |
+| ---------- | ------------------------------------- |
+| PR         | #14                                   |
+| Repository | Q-Summit/q-portal                     |
+| File       | `src/domain/qsum/shifts/constants.ts` |
+| Concern    | suggestion                            |
+| Status     | true (1 unresolved, 0 resolved)       |
+
+## Comments
+
+### Comment 2949147208 [UNRESOLVED]
+
+- **Line**: 8
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147208
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6d
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P2: Don't model "None" as a real tool value; represent no required tools with an empty array instead.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/constants.ts, line 8:
+
+<comment>Don't model "None" as a real tool value; represent no required tools with an empty array instead.</comment>
+
+<file context>
+@@ -0,0 +1,22 @@
++ * ────────────────────────────────────────────────────────────────────────── */
++
++export const TOOL_OPTIONS: readonly LabeledValue<Tool>[] = [
++  { value: "none", label: "None" },
++  { value: "car", label: "Car" },
++  { value: "van", label: "Van" },
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/b43cc083-2272-416f-a095-84adc62c593c" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-constants-ts-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-constants-ts-uncategorized.md
@@ -1,0 +1,75 @@
+# Cluster: src-domain-qsum-shifts-constants-ts-uncategorized
+
+## Context
+
+| Property   | Value                                 |
+| ---------- | ------------------------------------- |
+| PR         | #14                                   |
+| Repository | Q-Summit/q-portal                     |
+| File       | `src/domain/qsum/shifts/constants.ts` |
+| Concern    | uncategorized                         |
+| Status     | false (0 unresolved, 1 resolved)      |
+
+## Comments
+
+### Comment 2949147208 [RESOLVED]
+
+- **Line**: 8
+- **Author**: cubic-dev-ai[bot]
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147208
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6d
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P2: Don't model "None" as a real tool value; represent no required tools with an empty array instead.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/constants.ts, line 8:
+
+<comment>Don't model "None" as a real tool value; represent no required tools with an empty array instead.</comment>
+
+<file context>
+@@ -0,0 +1,22 @@
++ * ────────────────────────────────────────────────────────────────────────── */
++
++export const TOOL_OPTIONS: readonly LabeledValue<Tool>[] = [
++  { value: "none", label: "None" },
++  { value: "car", label: "Car" },
++  { value: "van", label: "Van" },
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-validation-ts-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-validation-ts-issue.md
@@ -1,0 +1,81 @@
+# Cluster: src-domain-qsum-shifts-validation-ts-issue
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/domain/qsum/shifts/validation.ts` |
+| Concern    | issue                                  |
+| Status     | true (1 unresolved, 0 resolved)        |
+
+## Comments
+
+### Comment 2949480924 [UNRESOLVED]
+
+- **Line**: 119
+- **Author**: cubic-dev-ai[bot]
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480924
+- **Thread ID**: PRRT_kwDOQS2Asc50_JtW
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/validation.ts, line 119:
+
+<comment>Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.</comment>
+
+<file context>
+@@ -87,20 +103,25 @@ export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;
+-    description: input.description?.trim() ?? null,
+-    notionLink: input.notionLink?.trim() ?? null,
++    description: blankToNull(input.description),
++    notionLink: blankToNull(input.notionLink),
+     startTime: input.startTime,
+     endTime: input.endTime,
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/1a0e54c7-91f2-4112-ba25-3c3d82a35003" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-validation-ts-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-domain-qsum-shifts-validation-ts-suggestion.md
@@ -1,0 +1,113 @@
+# Cluster: src-domain-qsum-shifts-validation-ts-suggestion
+
+## Context
+
+| Property   | Value                                  |
+| ---------- | -------------------------------------- |
+| PR         | #14                                    |
+| Repository | Q-Summit/q-portal                      |
+| File       | `src/domain/qsum/shifts/validation.ts` |
+| Concern    | suggestion                             |
+| Status     | false (0 unresolved, 3 resolved)       |
+
+## Comments
+
+### Comment 2949147269 [RESOLVED]
+
+- **Line**: 1
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147269
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7Q
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":10} -->
+P2: Whitespace-only descriptions are normalized to `""` instead of `null`. Use a falsy check here (and in the update normalizer) if blank descriptions should be treated as absent.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/validation.ts, line 97:
+
+<comment>Whitespace-only descriptions are normalized to `""` instead of `null`. Use a falsy check here (and in the update normalizer) if blank descriptions should be treated as absent.</comment>
+
+<file context>
+@@ -0,0 +1,121 @@
++  return {
++    location: input.location.trim(),
++    task: input.task.trim(),
++    description: input.description?.trim() ?? null,
++    notionLink: input.notionLink?.trim() ?? null,
++    startTime: input.startTime,
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+```
+
+---
+
+### Comment 2949159083 [RESOLVED]
+
+- **Line**: 56
+- **Author**: Copilot
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159083
+- **Thread ID**: PRRT_kwDOQS2Asc50-OIf
+
+**Body**:
+
+```
+
+`skillIds` and `tools` arrays allow duplicates (no uniqueness constraint), which will insert duplicate rows into `shift_skills` / `shift_tools`. Consider enforcing uniqueness in the Zod schemas (e.g. refine by Set size) or deduplicating in the normalizers before writing to the DB.
+
+```
+
+---
+
+### Comment 2949524498 [RESOLVED]
+
+- **Line**: 56
+- **Author**: LukasStrickler
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524498
+- **Thread ID**: PRRT_kwDOQS2Asc50-OIf
+
+**Body**:
+
+```
+
+Dismissed: Already handled: Zod schema validates uniqueness via Set size check, normalizers deduplicate arrays
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-lib-use-is-planner-ts-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-lib-use-is-planner-ts-security.md
@@ -1,0 +1,75 @@
+# Cluster: src-lib-use-is-planner-ts-security
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `src/lib/use-is-planner.ts`      |
+| Concern    | security                         |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147210 [RESOLVED]
+
+- **Line**: 14
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147210
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6f
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":6} -->
+P2: This hook uses `division === "chair"` instead of the new `isHeadOf` access flag, so authorized planners can be hidden from shift-management UI.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/lib/use-is-planner.ts, line 14:
+
+<comment>This hook uses `division === "chair"` instead of the new `isHeadOf` access flag, so authorized planners can be hidden from shift-management UI.</comment>
+
+<file context>
+@@ -0,0 +1,17 @@
++    refetchOnWindowFocus: false,
++  });
++
++  const isPlanner = data?.profile?.division === "chair";
++
++  return { isPlanner, isLoading };
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-issue.md
@@ -1,0 +1,75 @@
+# Cluster: src-server-api-routers-shift-ts-issue
+
+## Context
+
+| Property   | Value                             |
+| ---------- | --------------------------------- |
+| PR         | #14                               |
+| Repository | Q-Summit/q-portal                 |
+| File       | `src/server/api/routers/shift.ts` |
+| Concern    | issue                             |
+| Status     | false (0 unresolved, 1 resolved)  |
+
+## Comments
+
+### Comment 2949147166 [RESOLVED]
+
+- **Line**: 356
+- **Author**: cubic-dev-ai[bot]
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147166
+- **Thread ID**: PRRT_kwDOQS2Asc50-L57
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P1: `setHours(0, 0, 0, 0)` uses the server's local timezone to compute day boundaries. If the server doesn't run in UTC (common in deployment), the calendar query window shifts incorrectly—e.g., in CET it would query from 22:00 UTC the previous day to 22:00 UTC of the target day, returning wrong slots. Use `setUTCHours` and UTC date methods instead.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/api/routers/shift.ts, line 356:
+
+<comment>`setHours(0, 0, 0, 0)` uses the server's local timezone to compute day boundaries. If the server doesn't run in UTC (common in deployment), the calendar query window shifts incorrectly—e.g., in CET it would query from 22:00 UTC the previous day to 22:00 UTC of the target day, returning wrong slots. Use `setUTCHours` and UTC date methods instead.</comment>
+
+<file context>
+@@ -0,0 +1,529 @@
++    )
++    .query(async ({ ctx, input }) => {
++      const dayStart = new Date(input.date);
++      dayStart.setHours(0, 0, 0, 0);
++
++      const dayEnd = new Date(dayStart);
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-security.md
@@ -1,0 +1,68 @@
+# Cluster: src-server-api-routers-shift-ts-security
+
+## Context
+
+| Property   | Value                             |
+| ---------- | --------------------------------- |
+| PR         | #14                               |
+| Repository | Q-Summit/q-portal                 |
+| File       | `src/server/api/routers/shift.ts` |
+| Concern    | security                          |
+| Status     | false (0 unresolved, 2 resolved)  |
+
+## Comments
+
+### Comment 2949159310 [RESOLVED]
+
+- **Line**: 82
+- **Author**: Copilot
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159310
+- **Thread ID**: PRRT_kwDOQS2Asc50-OLT
+
+**Body**:
+
+```
+This router introduces substantial new behavior (planner authorization, slot generation/validation, CSV export). There are existing integration tests for other routers (e.g. `slack.integration.test.ts`), but no tests were added for the shift router. Consider adding integration tests for authz (FORBIDDEN vs OK), slot boundary validation, and CSV export formatting.
+```
+
+---
+
+### Comment 2949528326 [RESOLVED]
+
+- **Line**: 82
+- **Author**: LukasStrickler
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528326
+- **Thread ID**: PRRT_kwDOQS2Asc50-OLT
+
+**Body**:
+
+```
+Dismissed: Acknowledged: Integration tests deferred - router has comprehensive Storybook tests for UI validation
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: src-server-api-routers-shift-ts-suggestion
+
+## Context
+
+| Property   | Value                             |
+| ---------- | --------------------------------- |
+| PR         | #14                               |
+| Repository | Q-Summit/q-portal                 |
+| File       | `src/server/api/routers/shift.ts` |
+| Concern    | suggestion                        |
+| Status     | true (1 unresolved, 0 resolved)   |
+
+## Comments
+
+### Comment 2949480938 [UNRESOLVED]
+
+- **Line**: 526
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480938
+- **Thread ID**: PRRT_kwDOQS2Asc50_Jti
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/api/routers/shift.ts, line 526:
+
+<comment>Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.</comment>
+
+<file context>
+@@ -522,8 +523,7 @@ export const shiftRouter = createTRPCRouter({
+
+-    // UTF-8 BOM for German Excel compatibility
+-    const csv = "\uFEFF" + rows.join("\n");
++    const csv = rows.join("\n");
+     return { csv };
+   }),
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/640d8279-4968-4ae4-b3cd-2d5c5bd4670d" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-uncategorized.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-api-routers-shift-ts-uncategorized.md
@@ -1,0 +1,102 @@
+# Cluster: src-server-api-routers-shift-ts-uncategorized
+
+## Context
+
+| Property   | Value                             |
+| ---------- | --------------------------------- |
+| PR         | #14                               |
+| Repository | Q-Summit/q-portal                 |
+| File       | `src/server/api/routers/shift.ts` |
+| Concern    | uncategorized                     |
+| Status     | false (0 unresolved, 4 resolved)  |
+
+## Comments
+
+### Comment 2949159038 [RESOLVED]
+
+- **Line**: 440
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159038
+- **Thread ID**: PRRT_kwDOQS2Asc50-OH4
+
+**Body**:
+
+```
+`exportCsv` currently adds a UTF-8 BOM to the returned CSV (`"\uFEFF" + ...`). If the client is also adding a BOM, downloads will contain a double BOM. Align the API contract (either always include BOM server-side and never client-side, or vice versa) to avoid duplicate prefixes.
+```
+
+---
+
+### Comment 2949159057 [RESOLVED]
+
+- **Line**: 509
+- **Author**: Copilot
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159057
+- **Thread ID**: PRRT_kwDOQS2Asc50-OII
+
+**Body**:
+
+```
+`exportCsv` does `allShifts.find(...)` inside the loop over `allSlots`, making CSV generation O(shifts*slots). Build a `Map` from shiftId → shift once, then do O(1) lookups while iterating slots.
+```
+
+---
+
+### Comment 2949528414 [RESOLVED]
+
+- **Line**: 509
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528414
+- **Thread ID**: PRRT_kwDOQS2Asc50-OII
+
+**Body**:
+
+```
+Dismissed: Fixed: O(n^2) algorithm optimized with Map lookup in commit 018cd1f
+```
+
+---
+
+### Comment 2949528439 [RESOLVED]
+
+- **Line**: 440
+- **Author**: LukasStrickler
+- **Category**: uncategorized
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528439
+- **Thread ID**: PRRT_kwDOQS2Asc50-OH4
+
+**Body**:
+
+```
+Dismissed: Fixed: Aligned BOM handling - server adds BOM, client passes through
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-api-trpc-ts-security.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-api-trpc-ts-security.md
@@ -1,0 +1,73 @@
+# Cluster: src-server-api-trpc-ts-security
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `src/server/api/trpc.ts`         |
+| Concern    | security                         |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147195 [RESOLVED]
+
+- **Line**: 112
+- **Author**: cubic-dev-ai[bot]
+- **Category**: security
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147195
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6S
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P2: The `plannerMiddleware` duplicates the auth check from `authMiddleware`, violating the project's own anti-pattern guidance ("Manual auth checks in procedures — use `protectedProcedure`"). Build `plannerProcedure` on top of `protectedProcedure` and remove the redundant session check from `plannerMiddleware`.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/api/trpc.ts, line 112:
+
+<comment>The `plannerMiddleware` duplicates the auth check from `authMiddleware`, violating the project's own anti-pattern guidance ("Manual auth checks in procedures — use `protectedProcedure`"). Build `plannerProcedure` on top of `protectedProcedure` and remove the redundant session check from `plannerMiddleware`.</comment>
+
+<file context>
+@@ -72,3 +74,39 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
++  });
++});
++
++export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-db-migrations-0003-little-sandman-sql-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-db-migrations-0003-little-sandman-sql-suggestion.md
@@ -1,0 +1,81 @@
+# Cluster: src-server-db-migrations-0003-little-sandman-sql-suggestion
+
+## Context
+
+| Property   | Value                                               |
+| ---------- | --------------------------------------------------- |
+| PR         | #14                                                 |
+| Repository | Q-Summit/q-portal                                   |
+| File       | `src/server/db/_migrations/0003_little_sandman.sql` |
+| Concern    | suggestion                                          |
+| Status     | true (1 unresolved, 0 resolved)                     |
+
+## Comments
+
+### Comment 2949147190 [UNRESOLVED]
+
+- **Line**: 17
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147190
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6O
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P1: Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/db/_migrations/0003_little_sandman.sql, line 17:
+
+<comment>Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.</comment>
+
+<file context>
+@@ -0,0 +1,40 @@
++	FOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade
++);
++--> statement-breakpoint
++CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);--> statement-breakpoint
++CREATE TABLE `shift_tools` (
++	`id` text PRIMARY KEY NOT NULL,
+</file context>
+````
+
+</details>
+
+<a href="https://www.cubic.dev/action/fix/violation/974d55cc-0d1e-4429-a6d1-b8a51b8514ca" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/fix-with-cubic-light.svg">
+    <img alt="Fix with Cubic" src="https://cubic.dev/buttons/fix-with-cubic-dark.svg">
+  </picture>
+</a>
+```
+
+---
+
+## Completion Requirement
+
+**You must process ALL 1 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+```

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-db-schema-ts-issue.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-db-schema-ts-issue.md
@@ -1,0 +1,79 @@
+# Cluster: src-server-db-schema-ts-issue
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `src/server/db/schema.ts`        |
+| Concern    | issue                            |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147176 [RESOLVED]
+
+- **Line**: 172
+- **Author**: cubic-dev-ai[bot]
+- **Category**: issue
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147176
+- **Thread ID**: PRRT_kwDOQS2Asc50-L6C
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":9} -->
+P1: Missing `onDelete` on `createdBy` FK — deleting a user who created shifts will fail with a constraint error. Add `onDelete: "cascade"` (consistent with other domain FKs) or make the column nullable and use `onDelete: "set null"` if you want to preserve shift records.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/db/schema.ts, line 172:
+
+<comment>Missing `onDelete` on `createdBy` FK — deleting a user who created shifts will fail with a constraint error. Add `onDelete: "cascade"` (consistent with other domain FKs) or make the column nullable and use `onDelete: "set null"` if you want to preserve shift records.</comment>
+
+<file context>
+@@ -155,3 +156,57 @@ export const userTalent = sqliteTable(
++    endTime: integer("endTime", { mode: "timestamp" }).notNull(),
++    createdBy: text("createdBy")
++      .notNull()
++      .references(() => user.id),
++    createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
++  },
+</file context>
+````
+
+</details>
+
+```suggestion
+      .references(() => user.id, { onDelete: "cascade" }),
+```
+
+✅ Addressed in [`211ca78`](https://github.com/Q-Summit/q-portal/commit/211ca782045f967d2d1115eb252a5b193e13246d)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/clusters/src-server-db-schema-ts-suggestion.md
+++ b/.ada/data/pr-resolver/pr-14/clusters/src-server-db-schema-ts-suggestion.md
@@ -1,0 +1,75 @@
+# Cluster: src-server-db-schema-ts-suggestion
+
+## Context
+
+| Property   | Value                            |
+| ---------- | -------------------------------- |
+| PR         | #14                              |
+| Repository | Q-Summit/q-portal                |
+| File       | `src/server/db/schema.ts`        |
+| Concern    | suggestion                       |
+| Status     | false (0 unresolved, 1 resolved) |
+
+## Comments
+
+### Comment 2949147252 [RESOLVED]
+
+- **Line**: 196
+- **Author**: cubic-dev-ai[bot]
+- **Category**: suggestion
+- **Severity**:
+- **URL**: https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147252
+- **Thread ID**: PRRT_kwDOQS2Asc50-L7D
+
+**Body**:
+
+````
+<!-- metadata:{"confidence":8} -->
+P2: `shiftSkills` allows duplicate (shiftId, talentId) pairs — there's no unique constraint on the natural key. Consider adding a composite unique index (or switching to a composite PK like `userTalent` does) to prevent duplicates at the DB level.
+
+<details>
+<summary>Prompt for AI agents</summary>
+
+```text
+Check if this issue is valid — if so, understand the root cause and fix it. At src/server/db/schema.ts, line 196:
+
+<comment>`shiftSkills` allows duplicate (shiftId, talentId) pairs — there's no unique constraint on the natural key. Consider adding a composite unique index (or switching to a composite PK like `userTalent` does) to prevent duplicates at the DB level.</comment>
+
+<file context>
+@@ -155,3 +156,57 @@ export const userTalent = sqliteTable(
++  }),
++);
++
++export const shiftSkills = sqliteTable("shift_skills", {
++  id: text("id").primaryKey(),
++  shiftId: text("shiftId")
+</file context>
+````
+
+</details>
+
+✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)
+
+````
+
+---
+
+## Completion Requirement
+
+**You must process ALL 0 unresolved comments above before completing.**
+Do not return until every [UNRESOLVED] comment has been:
+- Fixed and resolved, OR
+- Dismissed with evidence, OR
+- Deferred with documentation
+
+## Resolution Commands
+
+After fixing issues in this cluster:
+
+```bash
+# Resolve a specific comment thread
+bash skills/resolve-pr-comments/scripts/pr-resolver-resolve.sh 14 <COMMENT_ID>
+
+# Dismiss as false positive
+bash skills/resolve-pr-comments/scripts/pr-resolver-dismiss.sh 14 <COMMENT_ID> "reason"
+````

--- a/.ada/data/pr-resolver/pr-14/data.json
+++ b/.ada/data/pr-resolver/pr-14/data.json
@@ -1,0 +1,1383 @@
+{
+  "pr_number": 14,
+  "repository": "Q-Summit/q-portal",
+  "generated_at": "2026-03-17T20:57:31Z",
+  "statistics": {
+    "total_comments": 82,
+    "resolved_comments": 62,
+    "unresolved_comments": 20,
+    "unique_in_clusters": 72,
+    "duplicates_detected": 10,
+    "clusters_created": 40,
+    "actionable_clusters": 9
+  },
+  "clusters": [
+    {
+      "cluster_id": "docs-shifts-readme-md-security",
+      "file": ".docs/shifts/README.md",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147214",
+          "path": ".docs/shifts/README.md",
+          "line": 71,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP2: This related-docs link points to a non-existent file, leaving the new auth reference unusable.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/README.md, line 71:\n\n<comment>This related-docs link points to a non-existent file, leaving the new auth reference unusable.</comment>\n\n<file context>\n@@ -0,0 +1,71 @@\n+\n+- [Development Setup](../guides/dev-setup.md) - Local development instructions\n+- [Database Schema](../db/schema.md) - Full database documentation\n+- [API Authentication](../api/authentication.md) - Auth flows and procedures\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147214",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6i",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "docs-shifts-csv-format-md-uncategorized",
+      "file": ".docs/shifts/csv-format.md",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147260",
+          "path": ".docs/shifts/csv-format.md",
+          "line": 191,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP2: The Node.js example does not actually parse the documented CSV format; splitting on `\\n` and `;` breaks valid quoted fields with semicolons or newlines.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/csv-format.md, line 191:\n\n<comment>The Node.js example does not actually parse the documented CSV format; splitting on `\\n` and `;` breaks valid quoted fields with semicolons or newlines.</comment>\n\n<file context>\n@@ -0,0 +1,240 @@\n+const headers = lines[0].split(\";\");\n+\n+const data = lines.slice(1).map((line) => {\n+  const values = line.split(\";\");\n+  return headers.reduce((obj, header, i) => {\n+    obj[header] = values[i];\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147260",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7I",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "docs-shifts-role-access-md-uncategorized",
+      "file": ".docs/shifts/role-access.md",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147158",
+          "path": ".docs/shifts/role-access.md",
+          "line": 36,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":7} -->\nP1: Documenting planner access as `division === \"chair\"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/role-access.md, line 36:\n\n<comment>Documenting planner access as `division === \"chair\"` contradicts the new `isHeadOf`-based RBAC and would exclude non-chair board members.</comment>\n\n<file context>\n@@ -0,0 +1,285 @@\n+A user is considered a **planner** if:\n+\n+1. They are logged in (authenticated)\n+2. Their profile has `division === \"chair\"`\n+\n+This includes:\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147158",
+          "thread_id": "PRRT_kwDOQS2Asc50-L5z",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "docs-shifts-workflow-md-import-fix",
+      "file": ".docs/shifts/workflow.md",
+      "concern": "import-fix",
+      "comments": [
+        {
+          "id": "2949147263",
+          "path": ".docs/shifts/workflow.md",
+          "line": 7,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The prerequisite documents the wrong access-control field. Planner access is described elsewhere as `isHeadOf`-based, so telling users to require `division = \"chair\"` will mislead Board users and admins.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .docs/shifts/workflow.md, line 7:\n\n<comment>The prerequisite documents the wrong access-control field. Planner access is described elsewhere as `isHeadOf`-based, so telling users to require `division = \"chair\"` will mislead Board users and admins.</comment>\n\n<file context>\n@@ -0,0 +1,192 @@\n+\n+## Prerequisites\n+\n+- You must be logged in with a Chair or Board role (division = \"chair\")\n+- Access the shift planning page via the main navigation\n+\n</file context>\n```\n\n</details>\n\n```suggestion\n- You must be logged in with planner access (`isHeadOf = true`, used for Chair/Board members)\n```\n\n✅ Addressed in [`211ca78`](https://github.com/Q-Summit/q-portal/commit/211ca782045f967d2d1115eb252a5b193e13246d)",
+          "category": "import-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147263",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7K",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "sisyphus-plans-shift-planning-md-security",
+      "file": ".sisyphus/plans/shift-planning.md",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147162",
+          "path": ".sisyphus/plans/shift-planning.md",
+          "line": 824,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 824:\n\n<comment>Protect the read/export procedures too; this plan currently leaves schedule data readable by any authenticated user.</comment>\n\n<file context>\n@@ -0,0 +1,1014 @@\n+\n+**What to do**:\n+\n+- Add plannerProcedure to create/update/delete\n+- Hide create button for non-planners\n+- Show edit/delete only for planners\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/22ff8753-e537-45ea-baae-630225272a43\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147162",
+          "thread_id": "PRRT_kwDOQS2Asc50-L52",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "sisyphus-plans-shift-planning-md-suggestion",
+      "file": ".sisyphus/plans/shift-planning.md",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147201",
+          "path": ".sisyphus/plans/shift-planning.md",
+          "line": 690,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At .sisyphus/plans/shift-planning.md, line 690:\n\n<comment>The fixed 06:00–23:00 grid cannot display the overnight slots that Task 15 requires for midnight-spanning shifts.</comment>\n\n<file context>\n@@ -0,0 +1,1014 @@\n+\n+- Create calendar component:\n+  - Day selector (April 9, April 10)\n+  - Y-axis: 30-min time slots (06:00-23:00)\n+  - X-axis: Locations OR just show total per slot\n+  - Cell shows headcount number\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/77bf3b3d-60fc-4023-bbbf-eca713b878a8\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147201",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6Y",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-app-mobile-shifts-page-tsx-security",
+      "file": "src/app/(mobile)/shifts/page.tsx",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949480919",
+          "path": "src/app/(mobile)/shifts/page.tsx",
+          "line": 27,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP2: Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 27:\n\n<comment>Avoid inlining another copy of the planner-role check; share the access rule with the existing planner authorization logic so page gating cannot drift from API enforcement.</comment>\n\n<file context>\n@@ -12,6 +15,21 @@ export default async function ShiftsPage() {\n+  ]);\n+\n+  const isHeadOf = userRow[0]?.isHeadOf ?? false;\n+  const isPlanner = profile?.division === \"chair\" || isHeadOf;\n+\n+  if (!isPlanner) {\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/90fb693f-e792-4f68-9d26-2f32c4fb73e2\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480919",
+          "thread_id": "PRRT_kwDOQS2Asc50_JtR",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-app-mobile-shifts-page-tsx-uncategorized",
+      "file": "src/app/(mobile)/shifts/page.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147153",
+          "path": "src/app/(mobile)/shifts/page.tsx",
+          "line": 35,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/page.tsx, line 17:\n\n<comment>This page now exposes shift schedules to any logged-in user because it renders `ShiftManager` without a planner-role check. That bypasses the PR’s stated “planners only” restriction for viewing shifts.</comment>\n\n<file context>\n@@ -13,9 +14,7 @@ export default async function ShiftsPage() {\n-      <h1 className=\"text-2xl font-bold text-foreground\">Shifts</h1>\n-      <p className=\"mt-2 text-muted-foreground\">Your upcoming shifts will appear here.</p>\n-      {/* TODO: Shifts list */}\n+      <ShiftManager />\n     </div>\n   );\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147153",
+          "thread_id": "PRRT_kwDOQS2Asc50-L5u",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-app-mobile-shifts-shifts-page-stories-tsx-suggestion",
+      "file": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147193",
+          "path": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+          "line": 301,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: These \"CalendarView\" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 300:\n\n<comment>These \"CalendarView\" stories never switch `ShiftManager` out of its default list mode, so they do not actually render or verify the calendar state.</comment>\n\n<file context>\n@@ -1,128 +1,349 @@\n+/**\n+ * Calendar view - showing shifts by time slots.\n+ */\n+export const CalendarView: Story = {\n+  parameters: {\n+    msw: {\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/b547a2b6-2b8c-42e3-9e08-736af6f76d6e\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147193",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6Q",
+          "resolved": false
+        },
+        {
+          "id": "2949147284",
+          "path": "src/app/(mobile)/shifts/shifts-page.stories.tsx",
+          "line": 278,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP3: Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/app/(mobile)/shifts/shifts-page.stories.tsx, line 263:\n\n<comment>Mock the default `shift.list` query in this loading story; otherwise it can hit an unhandled request instead of staying in the intended loading state.</comment>\n\n<file context>\n@@ -1,128 +1,349 @@\n+/**\n+ * Loading state - while fetching data.\n+ */\n+export const ListViewLoading: Story = {\n+  parameters: {\n+    msw: {\n</file context>\n```\n\n</details>\n\n```suggestion\nexport const ListViewLoading: Story = {\n  parameters: {\n    msw: {\n      handlers: [\n        trpcQuery(\"profile\", \"getMy\", async () => {\n          await new Promise((resolve) => setTimeout(resolve, 100000));\n          return {\n            user: mockUser,\n            profile: mockRegularProfile,\n          };\n        }),\n        trpcQuery(\"shift\", \"list\", async () => {\n          await new Promise((resolve) => setTimeout(resolve, 100000));\n          return {\n            items: [],\n            total: 0,\n            nextCursor: null,\n          };\n        }),\n      ],\n    },\n  },\n};\n```\n\n<a href=\"https://www.cubic.dev/action/fix/violation/fe755a28-2a23-4916-b388-cc627941f16b\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147284",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7d",
+          "resolved": false
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 0,
+      "unresolved_count": 2,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-components-shifts-calendar-view-stories-tsx-suggestion",
+      "file": "src/components/shifts/calendar-view.stories.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949232734",
+          "path": "src/components/shifts/calendar-view.stories.tsx",
+          "line": 829,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.stories.tsx, line 829:\n\n<comment>The new `bg-` filter is too broad and now clicks the first clickable time row instead of a shift cell.</comment>\n\n<file context>\n@@ -822,9 +822,14 @@ export const Interactive: Story = {\n+    const cells = canvasElement.querySelectorAll('[class*=\"cursor-pointer\"]');\n+    const shiftCells = Array.from(cells).filter((cell) => {\n+      const className = cell.className || '';\n+      return className.includes('bg-primary') || className.includes('bg-');\n+    });\n+    if (shiftCells.length > 0) {\n</file context>\n```\n\n</details>\n\n```suggestion\n      return className.includes('bg-primary');\n```\n\n<a href=\"https://www.cubic.dev/action/fix/violation/8dcbca12-3c1b-494a-85e1-788c48a67b0f\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949232734",
+          "thread_id": "PRRT_kwDOQS2Asc50-bUE",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-components-shifts-calendar-view-tsx-issue",
+      "file": "src/components/shifts/calendar-view.tsx",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949159228",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 217,
+          "author": "Copilot",
+          "body": "The modal close button is icon-only and missing an accessible name. Add `aria-label=\"Close\"` (or `sr-only` text) so assistive tech can identify the control.",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159228",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKV",
+          "resolved": true
+        },
+        {
+          "id": "2949524521",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 217,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Added aria-label='Close' to modal close button in commit 211ca78",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524521",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKV",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-calendar-view-tsx-suggestion",
+      "file": "src/components/shifts/calendar-view.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949159264",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 467,
+          "author": "Copilot",
+          "body": "The calendar cell click targets are `<div>` elements with `onClick` but no keyboard interaction support. Prefer a `<button>` for each cell (or add role/tabIndex/key handlers) so users can navigate and activate cells via keyboard.",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159264",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKu",
+          "resolved": true
+        },
+        {
+          "id": "2949524573",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 467,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Added role='button', tabIndex, and onKeyDown handler to grid cells in commit 211ca78",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524573",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKu",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-calendar-view-tsx-uncategorized",
+      "file": "src/components/shifts/calendar-view.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147172",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 96,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP1: The calendar rows are hard-coded to April 9, so switching to April 10 makes all slot lookups miss and the second day renders empty.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.tsx, line 96:\n\n<comment>The calendar rows are hard-coded to April 9, so switching to April 10 makes all slot lookups miss and the second day renders empty.</comment>\n\n<file context>\n@@ -0,0 +1,511 @@\n+/** Generate all 30-min time slots from START_HOUR to END_HOUR */\n+function generateTimeSlots(): Date[] {\n+  const slots: Date[] = [];\n+  const baseDate = new Date(2026, 3, 9); // Use April 9 as base\n+\n+  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147172",
+          "thread_id": "PRRT_kwDOQS2Asc50-L5-",
+          "resolved": true
+        },
+        {
+          "id": "2949147228",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 126,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Sum all matching shifts for a cell instead of showing only the first shift's headcount.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/calendar-view.tsx, line 126:\n\n<comment>Sum all matching shifts for a cell instead of showing only the first shift's headcount.</comment>\n\n<file context>\n@@ -0,0 +1,511 @@\n+  const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());\n+  if (!slot) return 0;\n+\n+  const shift = slot.shifts.find((sh) => sh.location === location);\n+  return shift?.headcount ?? 0;\n+}\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147228",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6u",
+          "resolved": true
+        },
+        {
+          "id": "2949159211",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 127,
+          "author": "Copilot",
+          "body": "`getHeadcountForSlot` only returns the first shift’s headcount for a given location/time, but there can be multiple shifts at the same location in the same slot. Sum the headcount across all matching shifts so the badge shows the correct total.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159211",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKH",
+          "resolved": true
+        },
+        {
+          "id": "2949159247",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 446,
+          "author": "Copilot",
+          "body": "Interactive grid cells are implemented as `<div onClick=...>`, which are not keyboard-accessible by default. Use semantic buttons/links, or add `role=\"button\"`, `tabIndex={0}`, and key handlers (Enter/Space) to meet keyboard accessibility requirements.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159247",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKh",
+          "resolved": true
+        },
+        {
+          "id": "2949524516",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 446,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Added keyboard accessibility to interactive grid cells in commit 211ca78",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524516",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKh",
+          "resolved": true
+        },
+        {
+          "id": "2949528437",
+          "path": "src/components/shifts/calendar-view.tsx",
+          "line": 127,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: getHeadcountForSlot now sums all matching shifts instead of returning first in commit 018cd1f",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528437",
+          "thread_id": "PRRT_kwDOQS2Asc50-OKH",
+          "resolved": true
+        }
+      ],
+      "total_comments": 6,
+      "resolved_count": 6,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-csv-export-button-stories-tsx-issue",
+      "file": "src/components/shifts/csv-export-button.stories.tsx",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949147221",
+          "path": "src/components/shifts/csv-export-button.stories.tsx",
+          "line": 112,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Match the MSW handler to `/api/trpc/shift.exportCsv`; the current route never intercepts this mutation, so the error story won't render the failure state.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/csv-export-button.stories.tsx, line 112:\n\n<comment>Match the MSW handler to `/api/trpc/shift.exportCsv`; the current route never intercepts this mutation, so the error story won't render the failure state.</comment>\n\n<file context>\n@@ -0,0 +1,164 @@\n+  parameters: {\n+    msw: {\n+      handlers: [\n+        http.post(\"*/api/trpc\", async ({ request }) => {\n+          const body = (await request.json()) as { json?: { params?: { path?: string } } };\n+          const path = body?.json?.params?.path;\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147221",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6o",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-csv-export-button-tsx-import-fix",
+      "file": "src/components/shifts/csv-export-button.tsx",
+      "concern": "import-fix",
+      "comments": [
+        {
+          "id": "2949159013",
+          "path": "src/components/shifts/csv-export-button.tsx",
+          "line": 10,
+          "author": "Copilot",
+          "body": "`React` is imported but never used in this file, which will trigger the repo's unused-vars warning. Remove the `import * as React from \"react\";` line.",
+          "category": "import-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159013",
+          "thread_id": "PRRT_kwDOQS2Asc50-OHh",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-components-shifts-csv-export-button-tsx-uncategorized",
+      "file": "src/components/shifts/csv-export-button.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949158993",
+          "path": "src/components/shifts/csv-export-button.tsx",
+          "line": 17,
+          "author": "Copilot",
+          "body": "`CsvExportButton` prepends a UTF-8 BOM to `data.csv`, but the server's `shift.exportCsv` response already includes a BOM. This will result in a double BOM in the downloaded file. Decide on a single source of truth (server or client) and remove the duplicate BOM addition.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158993",
+          "thread_id": "PRRT_kwDOQS2Asc50-OHN",
+          "resolved": true
+        },
+        {
+          "id": "2949524558",
+          "path": "src/components/shifts/csv-export-button.tsx",
+          "line": 17,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Client no longer adds BOM - server already includes it. Comment updated in code.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524558",
+          "thread_id": "PRRT_kwDOQS2Asc50-OHN",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-form-tsx-suggestion",
+      "file": "src/components/shifts/shift-form.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949159099",
+          "path": "src/components/shifts/shift-form.tsx",
+          "line": 232,
+          "author": "Copilot",
+          "body": "The `Label` components aren’t associated with their corresponding inputs (no `htmlFor` / matching `id`, and the label doesn't wrap the input). This hurts screen reader support. Add `id` on inputs and `htmlFor` on labels (or wrap the input with the label).",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159099",
+          "thread_id": "PRRT_kwDOQS2Asc50-OIs",
+          "resolved": true
+        },
+        {
+          "id": "2949524501",
+          "path": "src/components/shifts/shift-form.tsx",
+          "line": 232,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Associated labels with inputs via htmlFor/id and added fieldset/legend for groups in commit 211ca78",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524501",
+          "thread_id": "PRRT_kwDOQS2Asc50-OIs",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-form-tsx-uncategorized",
+      "file": "src/components/shifts/shift-form.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147171",
+          "path": "src/components/shifts/shift-form.tsx",
+          "line": 168,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP1: This create payload omits `slots`, so new shifts are always created with 0 headcount in every slot.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-form.tsx, line 154:\n\n<comment>This create payload omits `slots`, so new shifts are always created with 0 headcount in every slot.</comment>\n\n<file context>\n@@ -0,0 +1,428 @@\n+        startTime: new Date(form.startTime),\n+        endTime: new Date(form.endTime),\n+        skillIds: form.skillIds,\n+        tools: form.tools,\n+      },\n+      {\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147171",
+          "thread_id": "PRRT_kwDOQS2Asc50-L59",
+          "resolved": true
+        },
+        {
+          "id": "2949147224",
+          "path": "src/components/shifts/shift-form.tsx",
+          "line": 283,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Constrain both datetime inputs to 30-minute increments or the API will reject many submissions.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-form.tsx, line 257:\n\n<comment>Constrain both datetime inputs to 30-minute increments or the API will reject many submissions.</comment>\n\n<file context>\n@@ -0,0 +1,428 @@\n+            <div className=\"flex items-center gap-3\">\n+              <Calendar className=\"h-5 w-5 text-muted-foreground\" />\n+              <Input\n+                type=\"datetime-local\"\n+                aria-label=\"Start time\"\n+                className=\"h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0\"\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147224",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6q",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-list-stories-tsx-uncategorized",
+      "file": "src/components/shifts/shift-list.stories.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147244",
+          "path": "src/components/shifts/shift-list.stories.tsx",
+          "line": 245,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP2: The `play` function targets selectors that never exist, so this story silently skips the edit interaction.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.stories.tsx, line 245:\n\n<comment>The `play` function targets selectors that never exist, so this story silently skips the edit interaction.</comment>\n\n<file context>\n@@ -0,0 +1,338 @@\n+\n+    // Find and click the edit button on the first row\n+    const editButton =\n+      canvasElement.querySelector('[data-testid=\"edit-shift-1\"]') ??\n+      canvasElement.querySelector('button[title=\"Edit\"]');\n+\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147244",
+          "thread_id": "PRRT_kwDOQS2Asc50-L68",
+          "resolved": true
+        },
+        {
+          "id": "2949159285",
+          "path": "src/components/shifts/shift-list.stories.tsx",
+          "line": 247,
+          "author": "Copilot",
+          "body": "`InlineEditing` story tries to find an edit button via `[data-testid=\"edit-shift-1\"]` or `button[title=\"Edit\"]`, but the `ShiftList` component doesn’t render either attribute. The play function will likely do nothing. Add stable attributes to the component (e.g. `aria-label` or `data-testid`) and update the selector accordingly.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159285",
+          "thread_id": "PRRT_kwDOQS2Asc50-OK_",
+          "resolved": true
+        },
+        {
+          "id": "2949528409",
+          "path": "src/components/shifts/shift-list.stories.tsx",
+          "line": 247,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Added data-testid attributes to edit/delete buttons for story testing in commit 018cd1f",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528409",
+          "thread_id": "PRRT_kwDOQS2Asc50-OK_",
+          "resolved": true
+        }
+      ],
+      "total_comments": 3,
+      "resolved_count": 3,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-list-tsx-issue",
+      "file": "src/components/shifts/shift-list.tsx",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949159167",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 321,
+          "author": "Copilot",
+          "body": "The save/cancel buttons in the inline edit row are icon-only and missing accessible names. Add `aria-label`/`sr-only` text so screen readers can announce “Save” and “Cancel”.",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159167",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJi",
+          "resolved": true
+        },
+        {
+          "id": "2949524510",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 321,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Updated save/cancel button aria-labels in commit 211ca78",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524510",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJi",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-list-tsx-suggestion",
+      "file": "src/components/shifts/shift-list.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949159191",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 406,
+          "author": "Copilot",
+          "body": "`slotSummary.totalHeadcount === 0` is rendered as \"No slots\", but it really means the total required headcount is 0. This is misleading if slots exist but are unstaffed. Consider renaming the label or returning slot count separately.",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159191",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJ0",
+          "resolved": true
+        },
+        {
+          "id": "2949528468",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 406,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Acknowledged: Label 'No slots' indicates 0 total headcount - intentional design choice for clarity",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528468",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJ0",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-list-tsx-type-fix",
+      "file": "src/components/shifts/shift-list.tsx",
+      "concern": "type-fix",
+      "comments": [
+        {
+          "id": "2949159120",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 341,
+          "author": "Copilot",
+          "body": "`ShiftRowProps` is declared twice in the same file. TypeScript will merge these declarations, which can unintentionally change required/optional props and make the type harder to reason about. Consolidate into a single `ShiftRowProps` definition.",
+          "category": "type-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159120",
+          "thread_id": "PRRT_kwDOQS2Asc50-OI5",
+          "resolved": true
+        },
+        {
+          "id": "2949524584",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 341,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Verified: Only one ShiftRowProps declaration exists in the file - no duplicate to consolidate",
+          "category": "type-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524584",
+          "thread_id": "PRRT_kwDOQS2Asc50-OI5",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-list-tsx-uncategorized",
+      "file": "src/components/shifts/shift-list.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147238",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 231,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP2: Render the Actions `<td>` only for planners. Non-planner rows currently have an extra body cell that does not match the header columns.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.tsx, line 245:\n\n<comment>Render the Actions `<td>` only for planners. Non-planner rows currently have an extra body cell that does not match the header columns.</comment>\n\n<file context>\n@@ -0,0 +1,544 @@\n+\n+  return (\n+    <tr className=\"bg-accent/30\">\n+      <td className=\"px-4 py-3\">\n+        <div className=\"space-y-1\">\n+          <div className=\"flex items-center gap-2\">\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147238",
+          "thread_id": "PRRT_kwDOQS2Asc50-L63",
+          "resolved": true
+        },
+        {
+          "id": "2949147242",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 315,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Pass the shift's real `skillIds` into `SkillsBadge`. As written, the Skills column always renders empty for every shift.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-list.tsx, line 315:\n\n<comment>Pass the shift's real `skillIds` into `SkillsBadge`. As written, the Skills column always renders empty for every shift.</comment>\n\n<file context>\n@@ -0,0 +1,544 @@\n+        )}\n+      </td>\n+      <td className=\"px-4 py-3\">\n+        <SkillsBadge skillIds={[]} talents={talents} />\n+      </td>\n+      <td className=\"px-4 py-3\">\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147242",
+          "thread_id": "PRRT_kwDOQS2Asc50-L66",
+          "resolved": true
+        },
+        {
+          "id": "2949159134",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 415,
+          "author": "Copilot",
+          "body": "The skills column always renders an empty skills list (`skillIds={[]}`), so the UI will never show required skills even if they exist. Either remove the skills column from `ShiftList`, or extend the data model/API to include `skillIds` (or a summary) in the list items and pass the real values to `SkillsBadge`.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159134",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJH",
+          "resolved": true
+        },
+        {
+          "id": "2949159150",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 428,
+          "author": "Copilot",
+          "body": "The action buttons are icon-only but have no accessible name. Add `aria-label` (or an `sr-only` span) to the edit/delete buttons so they are usable with screen readers.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159150",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJW",
+          "resolved": true
+        },
+        {
+          "id": "2949524507",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 428,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Already fixed: Edit/delete buttons already have aria-labels (Edit shift/Delete shift)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524507",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJW",
+          "resolved": true
+        },
+        {
+          "id": "2949528431",
+          "path": "src/components/shifts/shift-list.tsx",
+          "line": 415,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Skills column now passes shift.skillIds to SkillsBadge in commit 018cd1f",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528431",
+          "thread_id": "PRRT_kwDOQS2Asc50-OJH",
+          "resolved": true
+        }
+      ],
+      "total_comments": 6,
+      "resolved_count": 6,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-manager-tsx-import-fix",
+      "file": "src/components/shifts/shift-manager.tsx",
+      "concern": "import-fix",
+      "comments": [
+        {
+          "id": "2949158885",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 16,
+          "author": "Copilot",
+          "body": "`AlertCircle` is imported but never used, which will trigger the repo's `@typescript-eslint/no-unused-vars` warning. Remove the import or use it in the component.",
+          "category": "import-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158885",
+          "thread_id": "PRRT_kwDOQS2Asc50-OFy",
+          "resolved": true
+        },
+        {
+          "id": "2949524524",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 16,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Verified: AlertCircle is not imported - only AlertTriangle is used",
+          "category": "import-fix",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524524",
+          "thread_id": "PRRT_kwDOQS2Asc50-OFy",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-manager-tsx-issue",
+      "file": "src/components/shifts/shift-manager.tsx",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949158966",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 190,
+          "author": "Copilot",
+          "body": "`navigateDay` allows moving to dates outside the API's allowed Q-Summit dates (Apr 9/10 2026), which will cause `shift.calendar` to error. Consider constraining navigation to the allowed date set (similar to `src/components/shifts/calendar-view.tsx`) or disabling prev/next when out of range.",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158966",
+          "thread_id": "PRRT_kwDOQS2Asc50-OG2",
+          "resolved": true
+        },
+        {
+          "id": "2949524489",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 190,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Verified: navigateDay already constrains to Q-Summit dates via QSUMMIT_DATES array",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524489",
+          "thread_id": "PRRT_kwDOQS2Asc50-OG2",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-manager-tsx-security",
+      "file": "src/components/shifts/shift-manager.tsx",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147255",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 311,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Use the planner flag here instead of `division === \"chair\"`; this hides create/export actions from authorized Board users.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-manager.tsx, line 311:\n\n<comment>Use the planner flag here instead of `division === \"chair\"`; this hides create/export actions from authorized Board users.</comment>\n\n<file context>\n@@ -0,0 +1,453 @@\n+    refetchOnWindowFocus: false,\n+  });\n+\n+  const isPlanner = profileData?.profile?.division === \"chair\";\n+\n+  // Fetch shifts list\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147255",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7F",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-manager-tsx-suggestion",
+      "file": "src/components/shifts/shift-manager.tsx",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949158943",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 137,
+          "author": "Copilot",
+          "body": "`slotSummary.totalHeadcount === 0` is being rendered as \"No slots\", but a shift can have slots with zero headcount. Consider changing the label (e.g. \"0 volunteers\"/\"Unstaffed\") or returning an explicit slot count from the API if you truly want to detect “no slots”.",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158943",
+          "thread_id": "PRRT_kwDOQS2Asc50-OGi",
+          "resolved": true
+        },
+        {
+          "id": "2949528435",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 137,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Acknowledged: Label 'No slots' indicates 0 total headcount - intentional design choice",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528435",
+          "thread_id": "PRRT_kwDOQS2Asc50-OGi",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-components-shifts-shift-manager-tsx-uncategorized",
+      "file": "src/components/shifts/shift-manager.tsx",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147295",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 197,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP3: Render the year from `selectedDate`; the hard-coded `2026` becomes wrong once the user navigates outside that year.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/components/shifts/shift-manager.tsx, line 197:\n\n<comment>Render the year from `selectedDate`; the hard-coded `2026` becomes wrong once the user navigates outside that year.</comment>\n\n<file context>\n@@ -0,0 +1,453 @@\n+              day: \"numeric\",\n+            })}\n+          </div>\n+          <div className=\"text-xs text-muted-foreground\">2026</div>\n+        </div>\n+        <Button variant=\"ghost\" size=\"icon\" onClick={() => navigateDay(\"next\")} className=\"h-9 w-9\">\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147295",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7m",
+          "resolved": true
+        },
+        {
+          "id": "2949158923",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 237,
+          "author": "Copilot",
+          "body": "The calendar navigation buttons are icon-only and currently have no accessible name. Add `aria-label` (or an `sr-only` label) to both the previous/next day buttons so screen readers can announce their purpose.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949158923",
+          "thread_id": "PRRT_kwDOQS2Asc50-OGS",
+          "resolved": true
+        },
+        {
+          "id": "2949524514",
+          "path": "src/components/shifts/shift-manager.tsx",
+          "line": 237,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Verified: Navigation buttons already have aria-labels (Previous day/Next day)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524514",
+          "thread_id": "PRRT_kwDOQS2Asc50-OGS",
+          "resolved": true
+        }
+      ],
+      "total_comments": 3,
+      "resolved_count": 3,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-domain-qsum-shifts-constants-ts-uncategorized",
+      "file": "src/domain/qsum/shifts/constants.ts",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949147208",
+          "path": "src/domain/qsum/shifts/constants.ts",
+          "line": 8,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP2: Don't model \"None\" as a real tool value; represent no required tools with an empty array instead.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/constants.ts, line 8:\n\n<comment>Don't model \"None\" as a real tool value; represent no required tools with an empty array instead.</comment>\n\n<file context>\n@@ -0,0 +1,22 @@\n+ * ────────────────────────────────────────────────────────────────────────── */\n+\n+export const TOOL_OPTIONS: readonly LabeledValue<Tool>[] = [\n+  { value: \"none\", label: \"None\" },\n+  { value: \"car\", label: \"Car\" },\n+  { value: \"van\", label: \"Van\" },\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147208",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6d",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-domain-qsum-shifts-validation-ts-issue",
+      "file": "src/domain/qsum/shifts/validation.ts",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949480924",
+          "path": "src/domain/qsum/shifts/validation.ts",
+          "line": 119,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/validation.ts, line 119:\n\n<comment>Blank `notionLink` values still fail schema validation before `blankToNull` runs, so clearing the optional Notion link remains broken.</comment>\n\n<file context>\n@@ -87,20 +103,25 @@ export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;\n-    description: input.description?.trim() ?? null,\n-    notionLink: input.notionLink?.trim() ?? null,\n+    description: blankToNull(input.description),\n+    notionLink: blankToNull(input.notionLink),\n     startTime: input.startTime,\n     endTime: input.endTime,\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/1a0e54c7-91f2-4112-ba25-3c3d82a35003\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480924",
+          "thread_id": "PRRT_kwDOQS2Asc50_JtW",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-domain-qsum-shifts-validation-ts-suggestion",
+      "file": "src/domain/qsum/shifts/validation.ts",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147269",
+          "path": "src/domain/qsum/shifts/validation.ts",
+          "line": 1,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":10} -->\nP2: Whitespace-only descriptions are normalized to `\"\"` instead of `null`. Use a falsy check here (and in the update normalizer) if blank descriptions should be treated as absent.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/domain/qsum/shifts/validation.ts, line 97:\n\n<comment>Whitespace-only descriptions are normalized to `\"\"` instead of `null`. Use a falsy check here (and in the update normalizer) if blank descriptions should be treated as absent.</comment>\n\n<file context>\n@@ -0,0 +1,121 @@\n+  return {\n+    location: input.location.trim(),\n+    task: input.task.trim(),\n+    description: input.description?.trim() ?? null,\n+    notionLink: input.notionLink?.trim() ?? null,\n+    startTime: input.startTime,\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147269",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7Q",
+          "resolved": true
+        },
+        {
+          "id": "2949159083",
+          "path": "src/domain/qsum/shifts/validation.ts",
+          "line": 56,
+          "author": "Copilot",
+          "body": "`skillIds` and `tools` arrays allow duplicates (no uniqueness constraint), which will insert duplicate rows into `shift_skills` / `shift_tools`. Consider enforcing uniqueness in the Zod schemas (e.g. refine by Set size) or deduplicating in the normalizers before writing to the DB.",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159083",
+          "thread_id": "PRRT_kwDOQS2Asc50-OIf",
+          "resolved": true
+        },
+        {
+          "id": "2949524498",
+          "path": "src/domain/qsum/shifts/validation.ts",
+          "line": 56,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Already handled: Zod schema validates uniqueness via Set size check, normalizers deduplicate arrays",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949524498",
+          "thread_id": "PRRT_kwDOQS2Asc50-OIf",
+          "resolved": true
+        }
+      ],
+      "total_comments": 3,
+      "resolved_count": 3,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-lib-use-is-planner-ts-security",
+      "file": "src/lib/use-is-planner.ts",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147210",
+          "path": "src/lib/use-is-planner.ts",
+          "line": 14,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":6} -->\nP2: This hook uses `division === \"chair\"` instead of the new `isHeadOf` access flag, so authorized planners can be hidden from shift-management UI.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/lib/use-is-planner.ts, line 14:\n\n<comment>This hook uses `division === \"chair\"` instead of the new `isHeadOf` access flag, so authorized planners can be hidden from shift-management UI.</comment>\n\n<file context>\n@@ -0,0 +1,17 @@\n+    refetchOnWindowFocus: false,\n+  });\n+\n+  const isPlanner = data?.profile?.division === \"chair\";\n+\n+  return { isPlanner, isLoading };\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147210",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6f",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-api-routers-shift-ts-issue",
+      "file": "src/server/api/routers/shift.ts",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949147166",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 356,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP1: `setHours(0, 0, 0, 0)` uses the server's local timezone to compute day boundaries. If the server doesn't run in UTC (common in deployment), the calendar query window shifts incorrectly—e.g., in CET it would query from 22:00 UTC the previous day to 22:00 UTC of the target day, returning wrong slots. Use `setUTCHours` and UTC date methods instead.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/api/routers/shift.ts, line 356:\n\n<comment>`setHours(0, 0, 0, 0)` uses the server's local timezone to compute day boundaries. If the server doesn't run in UTC (common in deployment), the calendar query window shifts incorrectly—e.g., in CET it would query from 22:00 UTC the previous day to 22:00 UTC of the target day, returning wrong slots. Use `setUTCHours` and UTC date methods instead.</comment>\n\n<file context>\n@@ -0,0 +1,529 @@\n+    )\n+    .query(async ({ ctx, input }) => {\n+      const dayStart = new Date(input.date);\n+      dayStart.setHours(0, 0, 0, 0);\n+\n+      const dayEnd = new Date(dayStart);\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147166",
+          "thread_id": "PRRT_kwDOQS2Asc50-L57",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-api-routers-shift-ts-security",
+      "file": "src/server/api/routers/shift.ts",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949159310",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 82,
+          "author": "Copilot",
+          "body": "This router introduces substantial new behavior (planner authorization, slot generation/validation, CSV export). There are existing integration tests for other routers (e.g. `slack.integration.test.ts`), but no tests were added for the shift router. Consider adding integration tests for authz (FORBIDDEN vs OK), slot boundary validation, and CSV export formatting.",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159310",
+          "thread_id": "PRRT_kwDOQS2Asc50-OLT",
+          "resolved": true
+        },
+        {
+          "id": "2949528326",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 82,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Acknowledged: Integration tests deferred - router has comprehensive Storybook tests for UI validation",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528326",
+          "thread_id": "PRRT_kwDOQS2Asc50-OLT",
+          "resolved": true
+        }
+      ],
+      "total_comments": 2,
+      "resolved_count": 2,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-api-routers-shift-ts-suggestion",
+      "file": "src/server/api/routers/shift.ts",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949480938",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 526,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/api/routers/shift.ts, line 526:\n\n<comment>Restore the UTF-8 BOM in the CSV response; both the docs and the download flow still assume BOM-prefixed output for Excel-compatible imports.</comment>\n\n<file context>\n@@ -522,8 +523,7 @@ export const shiftRouter = createTRPCRouter({\n \n-    // UTF-8 BOM for German Excel compatibility\n-    const csv = \"\\uFEFF\" + rows.join(\"\\n\");\n+    const csv = rows.join(\"\\n\");\n     return { csv };\n   }),\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/640d8279-4968-4ae4-b3cd-2d5c5bd4670d\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949480938",
+          "thread_id": "PRRT_kwDOQS2Asc50_Jti",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-server-api-routers-shift-ts-uncategorized",
+      "file": "src/server/api/routers/shift.ts",
+      "concern": "uncategorized",
+      "comments": [
+        {
+          "id": "2949159038",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 440,
+          "author": "Copilot",
+          "body": "`exportCsv` currently adds a UTF-8 BOM to the returned CSV (`\"\\uFEFF\" + ...`). If the client is also adding a BOM, downloads will contain a double BOM. Align the API contract (either always include BOM server-side and never client-side, or vice versa) to avoid duplicate prefixes.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159038",
+          "thread_id": "PRRT_kwDOQS2Asc50-OH4",
+          "resolved": true
+        },
+        {
+          "id": "2949159057",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 509,
+          "author": "Copilot",
+          "body": "`exportCsv` does `allShifts.find(...)` inside the loop over `allSlots`, making CSV generation O(shifts*slots). Build a `Map` from shiftId → shift once, then do O(1) lookups while iterating slots.",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949159057",
+          "thread_id": "PRRT_kwDOQS2Asc50-OII",
+          "resolved": true
+        },
+        {
+          "id": "2949528414",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 509,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: O(n^2) algorithm optimized with Map lookup in commit 018cd1f",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528414",
+          "thread_id": "PRRT_kwDOQS2Asc50-OII",
+          "resolved": true
+        },
+        {
+          "id": "2949528439",
+          "path": "src/server/api/routers/shift.ts",
+          "line": 440,
+          "author": "LukasStrickler",
+          "body": "Dismissed: Fixed: Aligned BOM handling - server adds BOM, client passes through",
+          "category": "uncategorized",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949528439",
+          "thread_id": "PRRT_kwDOQS2Asc50-OH4",
+          "resolved": true
+        }
+      ],
+      "total_comments": 4,
+      "resolved_count": 4,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-api-trpc-ts-security",
+      "file": "src/server/api/trpc.ts",
+      "concern": "security",
+      "comments": [
+        {
+          "id": "2949147195",
+          "path": "src/server/api/trpc.ts",
+          "line": 112,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP2: The `plannerMiddleware` duplicates the auth check from `authMiddleware`, violating the project's own anti-pattern guidance (\"Manual auth checks in procedures — use `protectedProcedure`\"). Build `plannerProcedure` on top of `protectedProcedure` and remove the redundant session check from `plannerMiddleware`.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/api/trpc.ts, line 112:\n\n<comment>The `plannerMiddleware` duplicates the auth check from `authMiddleware`, violating the project's own anti-pattern guidance (\"Manual auth checks in procedures — use `protectedProcedure`\"). Build `plannerProcedure` on top of `protectedProcedure` and remove the redundant session check from `plannerMiddleware`.</comment>\n\n<file context>\n@@ -72,3 +74,39 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {\n+  });\n+});\n+\n+export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "security",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147195",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6S",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-db-migrations-0003-little-sandman-sql-suggestion",
+      "file": "src/server/db/_migrations/0003_little_sandman.sql",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147190",
+          "path": "src/server/db/_migrations/0003_little_sandman.sql",
+          "line": 17,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/db/_migrations/0003_little_sandman.sql, line 17:\n\n<comment>Enforce `(shiftId, slotTime)` uniqueness in `shift_slots`; the current schema allows duplicate rows for one shift timeslice even though the API assumes they are impossible.</comment>\n\n<file context>\n@@ -0,0 +1,40 @@\n+\tFOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade\n+);\n+--> statement-breakpoint\n+CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);--> statement-breakpoint\n+CREATE TABLE `shift_tools` (\n+\t`id` text PRIMARY KEY NOT NULL,\n</file context>\n```\n\n</details>\n\n<a href=\"https://www.cubic.dev/action/fix/violation/974d55cc-0d1e-4429-a6d1-b8a51b8514ca\" target=\"_blank\" rel=\"noopener noreferrer\" data-no-image-dialog=\"true\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cubic.dev/buttons/fix-with-cubic-light.svg\">\n    <img alt=\"Fix with Cubic\" src=\"https://cubic.dev/buttons/fix-with-cubic-dark.svg\">\n  </picture>\n</a>",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147190",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6O",
+          "resolved": false
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 0,
+      "unresolved_count": 1,
+      "actionable": true
+    },
+    {
+      "cluster_id": "src-server-db-schema-ts-issue",
+      "file": "src/server/db/schema.ts",
+      "concern": "issue",
+      "comments": [
+        {
+          "id": "2949147176",
+          "path": "src/server/db/schema.ts",
+          "line": 172,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":9} -->\nP1: Missing `onDelete` on `createdBy` FK — deleting a user who created shifts will fail with a constraint error. Add `onDelete: \"cascade\"` (consistent with other domain FKs) or make the column nullable and use `onDelete: \"set null\"` if you want to preserve shift records.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/db/schema.ts, line 172:\n\n<comment>Missing `onDelete` on `createdBy` FK — deleting a user who created shifts will fail with a constraint error. Add `onDelete: \"cascade\"` (consistent with other domain FKs) or make the column nullable and use `onDelete: \"set null\"` if you want to preserve shift records.</comment>\n\n<file context>\n@@ -155,3 +156,57 @@ export const userTalent = sqliteTable(\n+    endTime: integer(\"endTime\", { mode: \"timestamp\" }).notNull(),\n+    createdBy: text(\"createdBy\")\n+      .notNull()\n+      .references(() => user.id),\n+    createdAt: integer(\"createdAt\", { mode: \"timestamp\" }).notNull(),\n+  },\n</file context>\n```\n\n</details>\n\n```suggestion\n      .references(() => user.id, { onDelete: \"cascade\" }),\n```\n\n✅ Addressed in [`211ca78`](https://github.com/Q-Summit/q-portal/commit/211ca782045f967d2d1115eb252a5b193e13246d)",
+          "category": "issue",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147176",
+          "thread_id": "PRRT_kwDOQS2Asc50-L6C",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    },
+    {
+      "cluster_id": "src-server-db-schema-ts-suggestion",
+      "file": "src/server/db/schema.ts",
+      "concern": "suggestion",
+      "comments": [
+        {
+          "id": "2949147252",
+          "path": "src/server/db/schema.ts",
+          "line": 196,
+          "author": "cubic-dev-ai[bot]",
+          "body": "<!-- metadata:{\"confidence\":8} -->\nP2: `shiftSkills` allows duplicate (shiftId, talentId) pairs — there's no unique constraint on the natural key. Consider adding a composite unique index (or switching to a composite PK like `userTalent` does) to prevent duplicates at the DB level.\n\n<details>\n<summary>Prompt for AI agents</summary>\n\n```text\nCheck if this issue is valid — if so, understand the root cause and fix it. At src/server/db/schema.ts, line 196:\n\n<comment>`shiftSkills` allows duplicate (shiftId, talentId) pairs — there's no unique constraint on the natural key. Consider adding a composite unique index (or switching to a composite PK like `userTalent` does) to prevent duplicates at the DB level.</comment>\n\n<file context>\n@@ -155,3 +156,57 @@ export const userTalent = sqliteTable(\n+  }),\n+);\n+\n+export const shiftSkills = sqliteTable(\"shift_skills\", {\n+  id: text(\"id\").primaryKey(),\n+  shiftId: text(\"shiftId\")\n</file context>\n```\n\n</details>\n\n✅ Addressed in [`018cd1f`](https://github.com/Q-Summit/q-portal/commit/018cd1f5c16d87f8617323aa13c03e524568e85a)",
+          "category": "suggestion",
+          "severity": "",
+          "url": "https://github.com/Q-Summit/q-portal/pull/14#discussion_r2949147252",
+          "thread_id": "PRRT_kwDOQS2Asc50-L7D",
+          "resolved": true
+        }
+      ],
+      "total_comments": 1,
+      "resolved_count": 1,
+      "unresolved_count": 0,
+      "actionable": false
+    }
+  ],
+  "duplicates": [
+    {
+      "comment_id": "2949147232",
+      "duplicate_of": "2949147193",
+      "reason": "semantic",
+      "similarity": "0.84"
+    },
+    {
+      "comment_id": "2949147248",
+      "duplicate_of": "2949147190",
+      "reason": "semantic",
+      "similarity": "0.80"
+    },
+    {
+      "comment_id": "2949147275",
+      "duplicate_of": "2949147162",
+      "reason": "semantic",
+      "similarity": "0.81"
+    },
+    {
+      "comment_id": "2949147280",
+      "duplicate_of": "2949147201",
+      "reason": "semantic",
+      "similarity": "0.80"
+    },
+    {
+      "comment_id": "2949147289",
+      "duplicate_of": "2949147284",
+      "reason": "semantic",
+      "similarity": "0.81"
+    },
+    {
+      "comment_id": "2949147290",
+      "duplicate_of": "2949147162",
+      "reason": "semantic",
+      "similarity": "0.80"
+    },
+    {
+      "comment_id": "2949248743",
+      "duplicate_of": "2949147193",
+      "reason": "semantic",
+      "similarity": "0.80"
+    },
+    {
+      "comment_id": "2949480915",
+      "duplicate_of": "2949147162",
+      "reason": "semantic",
+      "similarity": "0.82"
+    },
+    {
+      "comment_id": "2949480928",
+      "duplicate_of": "2949147193",
+      "reason": "semantic",
+      "similarity": "0.81"
+    },
+    {
+      "comment_id": "2949480942",
+      "duplicate_of": "2949147162",
+      "reason": "semantic",
+      "similarity": "0.81"
+    }
+  ],
+  "results": []
+}

--- a/.docs/shifts/README.md
+++ b/.docs/shifts/README.md
@@ -68,4 +68,4 @@ erDiagram
 
 - [Development Setup](../guides/dev-setup.md) - Local development instructions
 - [Database Schema](../db/schema.md) - Full database documentation
-- [API Authentication](../api/authentication.md) - Auth flows and procedures
+- [Authentication](../guides/flows/login-flow.md) - Auth flows and procedures

--- a/.docs/shifts/README.md
+++ b/.docs/shifts/README.md
@@ -1,0 +1,71 @@
+# Shift Planning Documentation
+
+Documentation for the Q-Summit 2026 volunteer shift planning system.
+
+## Overview
+
+The Shift Planning feature enables Chair and Board members to create, manage, and coordinate volunteer shifts for the Q-Summit event. It provides tools for scheduling shifts, assigning required skills and equipment, and exporting data for external coordination.
+
+## Quick Links
+
+- [Workflow](./workflow.md) - How to create and manage shifts
+- [CSV Format](./csv-format.md) - Export format specification
+- [Role Access](./role-access.md) - Who can access what
+- [API Reference](./api-reference.md) - Technical endpoint documentation
+
+## Key Features
+
+- **Shift Creation**: Define shifts with location, task, time slots, and requirements
+- **Calendar View**: Visualize shifts across the event days (April 9-10, 2026)
+- **List View**: Browse and filter all shifts
+- **CSV Export**: Export shift data for external tools (Excel, Google Sheets)
+- **Role-Based Access**: Restricted to Chair and Board members
+
+## Data Model
+
+A shift consists of:
+
+- **Basic Info**: Location, task description, optional Notion documentation link
+- **Time Schedule**: Start and end times with 30-minute slot granularity
+- **Requirements**: Required skills (talents) and tools/equipment
+- **Headcount**: Number of volunteers needed per time slot
+
+```mermaid
+erDiagram
+    Shift {
+        string id PK
+        string location
+        string task
+        string description
+        string notionLink
+        datetime startTime
+        datetime endTime
+        string createdBy FK
+        datetime createdAt
+    }
+    ShiftSlot {
+        string id PK
+        string shiftId FK
+        datetime slotTime
+        int headcount
+    }
+    ShiftSkill {
+        string id PK
+        string shiftId FK
+        string talentId FK
+    }
+    ShiftTool {
+        string id PK
+        string shiftId FK
+        string tool
+    }
+    Shift ||--o{ ShiftSlot : has
+    Shift ||--o{ ShiftSkill : requires
+    Shift ||--o{ ShiftTool : requires
+```
+
+## Related Documentation
+
+- [Development Setup](../guides/dev-setup.md) - Local development instructions
+- [Database Schema](../db/schema.md) - Full database documentation
+- [API Authentication](../api/authentication.md) - Auth flows and procedures

--- a/.docs/shifts/api-reference.md
+++ b/.docs/shifts/api-reference.md
@@ -467,7 +467,7 @@ const { data, isLoading, error } = api.shift.getById.useQuery(
 );
 
 // List shifts
-const { data, fetchNextPage } = api.shift.list.useQuery({
+const { data, hasNextPage, fetchNextPage } = api.shift.list.useInfiniteQuery({
   limit: 20,
   sortField: "startTime",
 });

--- a/.docs/shifts/api-reference.md
+++ b/.docs/shifts/api-reference.md
@@ -1,0 +1,519 @@
+# API Reference
+
+Technical documentation for the shift planning tRPC endpoints.
+
+## Base Path
+
+All shift endpoints are accessible via the `shift` router:
+
+```typescript
+api.shift.{procedureName}
+```
+
+## Authentication
+
+All endpoints require authentication via Better Auth session cookies. Some endpoints additionally require the planner role (Chair/Board).
+
+| Endpoint    | Procedure Type       | Auth Required | Planner Required |
+| ----------- | -------------------- | ------------- | ---------------- |
+| `create`    | `plannerProcedure`   | ✅            | ✅               |
+| `getById`   | `protectedProcedure` | ✅            | ❌               |
+| `update`    | `plannerProcedure`   | ✅            | ✅               |
+| `delete`    | `plannerProcedure`   | ✅            | ✅               |
+| `list`      | `protectedProcedure` | ✅            | ❌               |
+| `calendar`  | `protectedProcedure` | ✅            | ❌               |
+| `exportCsv` | `plannerProcedure`   | ✅            | ✅               |
+
+## Endpoints
+
+### Create Shift
+
+Creates a new shift with slots, skills, and tools.
+
+**Procedure:** `shift.create`
+
+**Input:** `ShiftCreateSchema`
+
+```typescript
+{
+  location: string;        // Required, 1-200 chars
+  task: string;            // Required, 1-200 chars
+  description?: string;    // Optional, max 2000 chars
+  notionLink?: string;     // Optional, must be notion.so URL
+  startTime: Date;         // Required
+  endTime: Date;           // Required, must be after startTime
+  skillIds: string[];      // Optional, default []
+  tools: Tool[];           // Optional, default []
+  slots?: SlotInput[];     // Optional, auto-generated if not provided
+}
+```
+
+**SlotInput:**
+
+```typescript
+{
+  slotTime: Date; // Must be on 30-min boundary
+  headcount: number; // 0-100, integer
+}
+```
+
+**Output:**
+
+```typescript
+{
+  ok: true;
+  id: string; // UUID of created shift
+}
+```
+
+**Validation Rules:**
+
+- `endTime` must be after `startTime`
+- All times must be on 30-minute boundaries
+- `notionLink` must be a valid notion.so URL
+- `slotTime` values must be within shift time range
+- Duplicate `slotTime` values are not allowed
+
+**Example:**
+
+```typescript
+api.shift.create.mutate({
+  location: "Main Hall",
+  task: "Registration Check-in",
+  description: "Check in attendees at the main entrance",
+  notionLink: "https://notion.so/registration-docs",
+  startTime: new Date("2026-04-09T08:00:00"),
+  endTime: new Date("2026-04-09T12:00:00"),
+  skillIds: ["tech-support", "customer-service"],
+  tools: ["car"],
+  slots: [
+    { slotTime: new Date("2026-04-09T08:00:00"), headcount: 2 },
+    { slotTime: new Date("2026-04-09T08:30:00"), headcount: 2 },
+  ],
+});
+```
+
+### Get Shift by ID
+
+Retrieves a single shift with all related data.
+
+**Procedure:** `shift.getById`
+
+**Input:**
+
+```typescript
+{
+  id: string; // Shift UUID
+}
+```
+
+**Output:**
+
+```typescript
+{
+  id: string;
+  location: string;
+  task: string;
+  description: string | null;
+  notionLink: string | null;
+  startTime: Date;
+  endTime: Date;
+  createdBy: string;
+  createdAt: Date;
+  skillIds: string[];      // Array of talent IDs
+  tools: Tool[];           // Array of tool values
+  slots: {
+    id: string;
+    slotTime: Date;
+    headcount: number;
+  }[];
+}
+```
+
+**Errors:**
+
+- `NOT_FOUND` - Shift does not exist
+
+**Example:**
+
+```typescript
+const { data } = api.shift.getById.useQuery({ id: "shift-uuid" });
+```
+
+### Update Shift
+
+Updates an existing shift, replacing all slots, skills, and tools.
+
+**Procedure:** `shift.update`
+
+**Input:** `ShiftUpdateSchema`
+
+```typescript
+{
+  id: string;              // Required, shift UUID
+  location: string;        // Required, 1-200 chars
+  task: string;            // Required, 1-200 chars
+  description?: string;    // Optional
+  notionLink?: string;     // Optional
+  startTime: Date;         // Required
+  endTime: Date;           // Required
+  skillIds: string[];      // Optional
+  tools: Tool[];           // Optional
+  slots?: SlotInput[];     // Optional
+}
+```
+
+**Output:**
+
+```typescript
+{
+  ok: true;
+}
+```
+
+**Note:** This is a full replacement update. All existing slots, skills, and tools are deleted and recreated.
+
+**Errors:**
+
+- `NOT_FOUND` - Shift does not exist
+
+**Example:**
+
+```typescript
+api.shift.update.mutate({
+  id: "shift-uuid",
+  location: "Updated Location",
+  task: "Updated Task",
+  startTime: new Date("2026-04-09T09:00:00"),
+  endTime: new Date("2026-04-09T13:00:00"),
+  skillIds: [],
+  tools: [],
+});
+```
+
+### Delete Shift
+
+Permanently removes a shift and all associated data.
+
+**Procedure:** `shift.delete`
+
+**Input:**
+
+```typescript
+{
+  id: string; // Shift UUID
+}
+```
+
+**Output:**
+
+```typescript
+{
+  ok: true;
+}
+```
+
+**Note:** This cascades to delete all related slots, skills, and tools.
+
+**Errors:**
+
+- `NOT_FOUND` - Shift does not exist
+
+**Example:**
+
+```typescript
+api.shift.delete.mutate({ id: "shift-uuid" });
+```
+
+### List Shifts
+
+Retrieves a paginated list of shifts with optional filtering.
+
+**Procedure:** `shift.list`
+
+**Input:**
+
+```typescript
+{
+  cursor?: number;         // Pagination offset, default 0
+  limit?: number;          // Items per page, default 20, max 50
+  sortField?: "startTime" | "location" | "task" | "createdAt";
+  sortDirection?: "asc" | "desc";
+  location?: string;       // Filter by location (partial match)
+  startDate?: Date;        // Filter: shifts starting on or after
+  endDate?: Date;          // Filter: shifts starting on or before
+}
+```
+
+**Output:**
+
+```typescript
+{
+  items: {
+    id: string;
+    location: string;
+    task: string;
+    description: string | null;
+    notionLink: string | null;
+    startTime: Date;
+    endTime: Date;
+    createdBy: string;
+    createdAt: Date;
+    slotSummary: {
+      totalHeadcount: number; // Sum of all slot headcounts
+    }
+  }
+  [];
+  total: number; // Total matching shifts
+  nextCursor: number | null; // Next cursor for pagination
+}
+```
+
+**Example:**
+
+```typescript
+const { data } = api.shift.list.useQuery({
+  limit: 50,
+  sortField: "startTime",
+  sortDirection: "asc",
+  location: "Main",
+  startDate: new Date("2026-04-09"),
+});
+```
+
+### Calendar View
+
+Retrieves shifts organized by time slots for a specific day.
+
+**Procedure:** `shift.calendar`
+
+**Input:**
+
+```typescript
+{
+  date: Date; // Must be April 9 or 10, 2026
+}
+```
+
+**Output:**
+
+```typescript
+{
+  slotTime: Date;
+  totalHeadcount: number; // Sum of headcounts for this slot
+  shifts: {
+    shiftId: string;
+    location: string;
+    task: string;
+    description: string | null;
+    notionLink: string | null;
+    startTime: Date;
+    endTime: Date;
+    headcount: number; // Headcount for this specific slot
+  }
+  [];
+}
+[];
+```
+
+**Validation:**
+
+- Date must be April 9 or 10, 2026 (Q-Summit dates)
+- Both local and UTC date interpretations are accepted
+
+**Example:**
+
+```typescript
+const { data } = api.shift.calendar.useQuery({
+  date: new Date("2026-04-09"),
+});
+```
+
+### Export CSV
+
+Exports all shift data as a CSV string.
+
+**Procedure:** `shift.exportCsv`
+
+**Input:** None
+
+**Output:**
+
+```typescript
+{
+  csv: string; // CSV content with UTF-8 BOM
+}
+```
+
+**CSV Format:**
+
+- Semicolon-delimited for German Excel compatibility
+- UTF-8 with BOM
+- One row per shift slot
+- See [CSV Format](./csv-format.md) for full specification
+
+**Example:**
+
+```typescript
+const mutation = api.shift.exportCsv.useMutation({
+  onSuccess: (data) => {
+    const blob = new Blob([data.csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "shifts-export.csv";
+    link.click();
+  },
+});
+
+mutation.mutate();
+```
+
+## Domain Types
+
+### Tool
+
+```typescript
+type Tool = "car" | "van" | "equipment" | "none";
+```
+
+### Shift
+
+```typescript
+interface Shift {
+  id: string;
+  location: string;
+  task: string;
+  description: string | null;
+  notionLink: string | null;
+  startTime: Date;
+  endTime: Date;
+  createdBy: string;
+  createdAt: Date;
+}
+```
+
+### ShiftSlot
+
+```typescript
+interface ShiftSlot {
+  id: string;
+  shiftId: string;
+  slotTime: Date;
+  headcount: number;
+}
+```
+
+### ShiftSkill
+
+```typescript
+interface ShiftSkill {
+  id: string;
+  shiftId: string;
+  talentId: string;
+}
+```
+
+### ShiftTool
+
+```typescript
+interface ShiftTool {
+  id: string;
+  shiftId: string;
+  tool: Tool;
+}
+```
+
+## Error Codes
+
+| Code                    | HTTP Status | Description             |
+| ----------------------- | ----------- | ----------------------- |
+| `UNAUTHORIZED`          | 401         | User not logged in      |
+| `FORBIDDEN`             | 403         | User lacks planner role |
+| `NOT_FOUND`             | 404         | Shift not found         |
+| `BAD_REQUEST`           | 400         | Invalid input data      |
+| `INTERNAL_SERVER_ERROR` | 500         | Unexpected server error |
+
+## Validation Errors
+
+When validation fails, the error includes Zod field errors:
+
+```typescript
+{
+  error: {
+    code: "BAD_REQUEST",
+    message: "Invalid input",
+    data: {
+      zodError: {
+        fieldErrors: {
+          endTime: ["End time must be after start time"],
+          location: ["Location is required"],
+        },
+      },
+    },
+  },
+}
+```
+
+## React Hook Usage
+
+### Queries (Read)
+
+```typescript
+// Get shift by ID
+const { data, isLoading, error } = api.shift.getById.useQuery(
+  { id: "shift-uuid" },
+  { enabled: !!id }, // Only run when ID exists
+);
+
+// List shifts
+const { data, fetchNextPage } = api.shift.list.useQuery({
+  limit: 20,
+  sortField: "startTime",
+});
+
+// Calendar view
+const { data } = api.shift.calendar.useQuery(
+  { date: selectedDate },
+  { enabled: viewMode === "calendar" },
+);
+```
+
+### Mutations (Write)
+
+```typescript
+// Create
+const create = api.shift.create.useMutation({
+  onSuccess: (data) => {
+    console.log("Created shift:", data.id);
+  },
+  onError: (error) => {
+    console.error("Failed:", error.message);
+  },
+});
+
+create.mutate({ location: "...", task: "...", ... });
+
+// Update
+const update = api.shift.update.useMutation();
+update.mutate({ id: "...", location: "...", ... });
+
+// Delete
+const deleteMutation = api.shift.delete.useMutation();
+deleteMutation.mutate({ id: "..." });
+
+// Export
+const exportCsv = api.shift.exportCsv.useMutation({
+  onSuccess: (data) => {
+    // Trigger download
+  },
+});
+exportCsv.mutate();
+```
+
+## Related Documentation
+
+- [Workflow](./workflow.md) - How to use these endpoints
+- [CSV Format](./csv-format.md) - CSV export format details
+- [Role Access](./role-access.md) - Authentication and authorization
+- [Domain Types](../../src/domain/qsum/shifts/types.ts) - TypeScript type definitions

--- a/.docs/shifts/csv-format.md
+++ b/.docs/shifts/csv-format.md
@@ -1,0 +1,240 @@
+# CSV Export Format
+
+Specification for the shift data CSV export.
+
+## Overview
+
+The CSV export feature allows planners to download all shift data for use in external tools like Excel, Google Sheets, or other planning software. The format is optimized for German Excel compatibility.
+
+## File Format
+
+### Encoding
+
+- **UTF-8 with BOM**: The file starts with a UTF-8 Byte Order Mark (`\uFEFF`) for proper character encoding in Excel
+- **Line endings**: Unix-style (`\n`)
+
+### Delimiter
+
+- **Semicolon (`;`)**: Used instead of comma for German Excel compatibility
+- German Excel uses semicolon as the default list separator
+
+### Escaping
+
+Fields containing semicolons, quotes, or newlines are wrapped in double quotes:
+
+```
+"Field with ; semicolon"
+"Field with ""quotes"""
+```
+
+## Column Structure
+
+| Column        | Type            | Description                     | Example                                |
+| ------------- | --------------- | ------------------------------- | -------------------------------------- |
+| `shift_id`    | UUID            | Unique identifier for the shift | `550e8400-e29b-41d4-a716-446655440000` |
+| `location`    | String          | Where the shift takes place     | `Main Hall`                            |
+| `task`        | String          | Description of the work         | `Registration Check-in`                |
+| `start_time`  | ISO DateTime    | When the shift begins           | `2026-04-09 08:00:00`                  |
+| `end_time`    | ISO DateTime    | When the shift ends             | `2026-04-09 12:00:00`                  |
+| `slot_time`   | ISO DateTime    | Specific 30-minute slot         | `2026-04-09 08:00:00`                  |
+| `headcount`   | Integer         | Volunteers needed for this slot | `2`                                    |
+| `skills`      | Comma-separated | Required talent IDs             | `tech-support,first-aid`               |
+| `tools`       | Comma-separated | Required tools                  | `car,equipment`                        |
+| `notion_link` | URL             | Documentation link (optional)   | `https://notion.so/page`               |
+
+## Header Row
+
+```
+shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
+```
+
+## Example Data
+
+### Single Shift with Multiple Slots
+
+A shift from 08:00 to 10:00 with 30-minute slots:
+
+```csv
+shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
+550e8400-e29b-41d4-a716-446655440000;Main Hall;Registration;2026-04-09 08:00:00;2026-04-09 10:00:00;2026-04-09 08:00:00;2;tech-support;car;https://notion.so/page
+550e8400-e29b-41d4-a716-446655440000;Main Hall;Registration;2026-04-09 08:00:00;2026-04-09 10:00:00;2026-04-09 08:30:00;2;tech-support;car;https://notion.so/page
+550e8400-e29b-41d4-a716-446655440000;Main Hall;Registration;2026-04-09 08:00:00;2026-04-09 10:00:00;2026-04-09 09:00:00;3;tech-support;car;https://notion.so/page
+550e8400-e29b-41d4-a716-446655440000;Main Hall;Registration;2026-04-09 08:00:00;2026-04-09 10:00:00;2026-04-09 09:30:00;3;tech-support;car;https://notion.so/page
+```
+
+**Note:** The same shift appears multiple times, once per slot. This allows different headcounts per time slot.
+
+### Multiple Shifts
+
+```csv
+shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
+550e8400-e29b-41d4-a716-446655440000;Main Hall;Registration;2026-04-09 08:00:00;2026-04-09 10:00:00;2026-04-09 08:00:00;2;tech-support;car;
+550e8400-e29b-41d4-a716-446655440001;Cafeteria;Food Service;2026-04-09 09:00:00;2026-04-09 14:00:00;2026-04-09 09:00:00;4;cooking;none;https://notion.so/food
+550e8400-e29b-41d4-a716-446655440001;Cafeteria;Food Service;2026-04-09 09:00:00;2026-04-09 14:00:00;2026-04-09 09:30:00;4;cooking;none;https://notion.so/food
+```
+
+### Empty Export
+
+When no shifts exist:
+
+```csv
+shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
+```
+
+Only the header row is included.
+
+## DateTime Format
+
+Dates are formatted as ISO 8601 with a space separator:
+
+```
+YYYY-MM-DD HH:MM:SS
+```
+
+**Examples:**
+
+- `2026-04-09 08:00:00` - April 9, 2026 at 8:00 AM
+- `2026-04-09 14:30:00` - April 9, 2026 at 2:30 PM
+
+**Note:** The `T` separator is replaced with a space for better Excel compatibility.
+
+## Skills and Tools Format
+
+### Skills
+
+Skills are stored as comma-separated talent IDs:
+
+```
+tech-support,first-aid,customer-service
+```
+
+If no skills are required, the field is empty.
+
+### Tools
+
+Tools are stored as comma-separated values from the allowed set:
+
+```
+car,van,equipment
+```
+
+Allowed values: `car`, `van`, `equipment`, `none`
+
+If no tools are required, the field is empty.
+
+## Special Characters
+
+### Location and Task Fields
+
+If location or task contains special characters, they are escaped:
+
+| Input                | CSV Output               |
+| -------------------- | ------------------------ |
+| `Room A; Building 1` | `"Room A; Building 1"`   |
+| `Task with "quotes"` | `"Task with ""quotes"""` |
+| `Multi\nline`        | `"Multi\nline"`          |
+
+### Notion Link
+
+The Notion link field is optional and may be empty:
+
+```csv
+shift_id;location;task;...;notion_link
+550e8400...;Main Hall;Registration;...;https://notion.so/page
+550e8401...;Cafeteria;Cleanup;...;
+```
+
+## Usage in Excel
+
+### Opening in German Excel
+
+1. Open Excel
+2. Go to **Data** > **From Text/CSV**
+3. Select the downloaded file
+4. Set encoding to **UTF-8**
+5. Set delimiter to **Semicolon**
+6. Click **Load**
+
+### Opening in Google Sheets
+
+1. Open Google Sheets
+2. Go to **File** > **Import**
+3. Upload the CSV file
+4. Select **Semicolon** as separator
+5. Click **Import data**
+
+## Programmatic Usage
+
+### Python (pandas)
+
+```python
+import pandas as pd
+
+# Read with semicolon delimiter and UTF-8 encoding
+df = pd.read_csv('shifts-export.csv', sep=';', encoding='utf-8-sig')
+
+# The utf-8-sig encoding handles the BOM automatically
+print(df.head())
+```
+
+### JavaScript/Node.js
+
+```javascript
+const fs = require("fs");
+
+// Read and parse CSV
+const csv = fs.readFileSync("shifts-export.csv", "utf8");
+const lines = csv.trim().split("\n");
+const headers = lines[0].split(";");
+
+const data = lines.slice(1).map((line) => {
+  const values = line.split(";");
+  return headers.reduce((obj, header, i) => {
+    obj[header] = values[i];
+    return obj;
+  }, {});
+});
+
+console.log(data);
+```
+
+## Export Process
+
+```mermaid
+sequenceDiagram
+    actor Planner
+    participant UI as CSV Export Button
+    participant API as shift.exportCsv
+    participant DB as Database
+
+    Planner->>UI: Click Export
+    UI->>API: Call exportCsv mutation
+    API->>DB: Query all shifts
+    API->>DB: Query all slots
+    API->>DB: Query all skills
+    API->>DB: Query all tools
+    DB-->>API: Return raw data
+    API->>API: Aggregate skills by shift
+    API->>API: Aggregate tools by shift
+    API->>API: Format datetime (ISO with space)
+    API->>API: Escape special characters
+    API->>API: Build CSV rows
+    API->>API: Add UTF-8 BOM prefix
+    API-->>UI: Return CSV string
+    UI->>UI: Create Blob with text/csv type
+    UI->>UI: Trigger file download
+    UI-->>Planner: File downloaded
+```
+
+## Limitations
+
+- **Read-only**: The export is one-way; changes cannot be imported back
+- **No history**: Previous versions of shifts are not included
+- **Current state only**: Only the latest shift data is exported
+- **No user assignments**: Individual volunteer assignments are not included (future feature)
+
+## Related Documentation
+
+- [Workflow](./workflow.md) - How to create and manage shifts
+- [Role Access](./role-access.md) - Who can export data
+- [API Reference](./api-reference.md) - Technical details of the export endpoint

--- a/.docs/shifts/csv-format.md
+++ b/.docs/shifts/csv-format.md
@@ -179,21 +179,63 @@ print(df.head())
 
 ### JavaScript/Node.js
 
+The format uses quoted fields for values containing semicolons, quotes, or newlines (see [Escaping](#escaping)). Use a parser that respects quotes instead of splitting only on `\n` and `;`.
+
 ```javascript
 const fs = require("fs");
 
-// Read and parse CSV
-const csv = fs.readFileSync("shifts-export.csv", "utf8");
-const lines = csv.trim().split("\n");
-const headers = lines[0].split(";");
+function parseSemicolonCsv(csvText) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < csvText.length; i++) {
+    const c = csvText[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (csvText[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else {
+      if (c === '"') {
+        inQuotes = true;
+      } else if (c === ";") {
+        row.push(field);
+        field = "";
+      } else if (c === "\n" || c === "\r") {
+        if (c === "\r" && csvText[i + 1] === "\n") i++;
+        row.push(field);
+        field = "";
+        if (row.length > 0 && row.some((cell) => cell !== "")) rows.push(row);
+        row = [];
+      } else {
+        field += c;
+      }
+    }
+  }
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    if (row.some((cell) => cell !== "")) rows.push(row);
+  }
+  return rows;
+}
 
-const data = lines.slice(1).map((line) => {
-  const values = line.split(";");
-  return headers.reduce((obj, header, i) => {
-    obj[header] = values[i];
+// Read and parse CSV (handles UTF-8 BOM)
+const csv = fs.readFileSync("shifts-export.csv", "utf8");
+const rows = parseSemicolonCsv(csv.replace(/^\uFEFF/, ""));
+const headers = rows[0];
+const data = rows.slice(1).map((values) =>
+  headers.reduce((obj, header, i) => {
+    obj[header] = values[i] ?? "";
     return obj;
-  }, {});
-});
+  }, {}),
+);
 
 console.log(data);
 ```

--- a/.docs/shifts/role-access.md
+++ b/.docs/shifts/role-access.md
@@ -10,8 +10,8 @@ Shift planning functionality is restricted to **Chair and Board members** only. 
 
 ```
 ┌─────────────────────────────────────┐
-│           Chair/Board               │  ← Full shift planning access
-│         (division = "chair")          │
+│  Planners (full shift access)       │  ← division = "chair" OR user.isHeadOf
+│  Chair/Board + authorized heads     │
 └─────────────────────────────────────┘
                   │
                   ▼
@@ -33,16 +33,16 @@ Shift planning functionality is restricted to **Chair and Board members** only. 
 A user is considered a **planner** if:
 
 1. They are logged in (authenticated)
-2. Their profile has `division === "chair"`
+2. They have planner authorization: **either** their profile has `division === "chair"` **or** their user record has `isHeadOf === true`
 
 This includes:
 
-- **Chairman**: The event chair
-- **Board Members**: Members of the organizing board
+- **Chair/Board**: Profile `division === "chair"` (Chairman and board members)
+- **Authorized heads**: Non-chair users marked as team leads via the `user.isHeadOf` flag (e.g. board members or other leads granted planner access)
 
 ### How the Role is Checked
 
-The `useIsPlanner` hook checks the user's profile:
+The `useIsPlanner` hook checks both profile division and the `isHeadOf` access flag:
 
 ```typescript
 // src/lib/use-is-planner.ts
@@ -51,7 +51,7 @@ export function useIsPlanner(): { isPlanner: boolean; isLoading: boolean } {
     refetchOnWindowFocus: false,
   });
 
-  const isPlanner = data?.profile?.division === "chair";
+  const isPlanner = (data?.profile?.division === "chair" || data?.user?.isHeadOf === true) ?? false;
 
   return { isPlanner, isLoading };
 }
@@ -76,11 +76,11 @@ This hook is used in components to conditionally show planner-only features.
 
 The tRPC router uses different procedure types to enforce access control:
 
-| Procedure            | Authentication | Authorization          | Use Case                          |
-| -------------------- | -------------- | ---------------------- | --------------------------------- |
-| `publicProcedure`    | None           | None                   | Public data (not used for shifts) |
-| `protectedProcedure` | Required       | None                   | Authenticated users can access    |
-| `plannerProcedure`   | Required       | `division === "chair"` | Planners only                     |
+| Procedure            | Authentication | Authorization                             | Use Case                          |
+| -------------------- | -------------- | ----------------------------------------- | --------------------------------- |
+| `publicProcedure`    | None           | None                                      | Public data (not used for shifts) |
+| `protectedProcedure` | Required       | None                                      | Authenticated users can access    |
+| `plannerProcedure`   | Required       | `division === "chair"` or `user.isHeadOf` | Planners only                     |
 
 ### Protected Endpoints
 
@@ -109,38 +109,34 @@ The tRPC router uses different procedure types to enforce access control:
 
 ### Middleware Implementation
 
-The `plannerProcedure` uses middleware to enforce access:
+The `plannerProcedure` is built on `protectedProcedure` and uses middleware to enforce planner access via `division === "chair"` or `user.isHeadOf`:
 
 ```typescript
 // src/server/api/trpc.ts
 const plannerMiddleware = t.middleware(async ({ ctx, next }) => {
-  // Check authentication
-  if (!ctx?.session?.user) {
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "You must be logged in to perform this action",
-    });
-  }
-
   const userId = ctx.session.user.id;
 
-  // Get user's profile
-  const profile = await ctx.db.query.memberProfile.findFirst({
-    where: eq(memberProfile.userId, userId),
-  });
+  const [profile, userRow] = await Promise.all([
+    ctx.db.query.memberProfile.findFirst({
+      where: eq(memberProfile.userId, userId),
+    }),
+    ctx.db.select({ isHeadOf: user.isHeadOf }).from(user).where(eq(user.id, userId)).limit(1),
+  ]);
 
-  // Check division
-  if (profile?.division !== "chair") {
+  const isHeadOf = userRow[0]?.isHeadOf ?? false;
+  const isPlanner = profile?.division === "chair" || isHeadOf;
+
+  if (!isPlanner) {
     throw new TRPCError({
       code: "FORBIDDEN",
-      message: "Only Chair/Board members can access shift planning",
+      message: "Only Chair/Board members or heads can access shift planning",
     });
   }
 
   return next({ ctx });
 });
 
-export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);
+export const plannerProcedure = protectedProcedure.use(plannerMiddleware);
 ```
 
 ## UI-Level Protection
@@ -152,7 +148,8 @@ UI components check the planner role before showing controls:
 ```typescript
 // In ShiftManager component
 const { data: profileData, isLoading: isProfileLoading } = api.profile.getMy.useQuery(...);
-const isPlanner = profileData?.profile?.division === "chair";
+const isPlanner =
+  (profileData?.profile?.division === "chair" || profileData?.user?.isHeadOf === true) ?? false;
 
 // Only show Create button to planners
 {isPlanner && (
@@ -187,7 +184,7 @@ When a non-planner tries to access planner-only endpoints:
 {
   "error": {
     "code": "FORBIDDEN",
-    "message": "Only Chair/Board members can access shift planning"
+    "message": "Only Chair/Board members or heads can access shift planning"
   }
 }
 ```
@@ -245,18 +242,21 @@ Sessions are:
 
 ### How Roles Are Assigned
 
-Roles are stored in the `memberProfile` table:
+Planner access is determined by two places:
 
-| Column     | Type   | Description                                 |
-| ---------- | ------ | ------------------------------------------- |
-| `userId`   | string | Link to user account                        |
-| `division` | string | Role/division ("chair", "operations", etc.) |
+- **Profile**: `member_profile.division` — `"chair"` grants planner access (Chair/Board).
+- **User**: `user.isHeadOf` — when `true`, grants planner access (authorized heads / team leads).
+
+| Location         | Column     | Type    | Description                                   |
+| ---------------- | ---------- | ------- | --------------------------------------------- |
+| `member_profile` | `division` | string  | Role/division ("chair", "operations", etc.)   |
+| `user`           | `isHeadOf` | boolean | When true, user is a planner (e.g. team lead) |
 
 ### Updating a User's Role
 
-To grant planner access:
+To grant planner access, use either (or both):
 
-1. Update the user's profile in the database:
+1. **Chair/Board**: Set profile division to `'chair'`:
 
 ```sql
 UPDATE member_profile
@@ -264,22 +264,30 @@ SET division = 'chair'
 WHERE user_id = 'user-uuid-here';
 ```
 
-2. The user must log out and log back in for changes to take effect
+2. **Head / team lead**: Set the user's `isHeadOf` flag:
+
+```sql
+UPDATE user
+SET isHeadOf = 1
+WHERE id = 'user-uuid-here';
+```
+
+The user may need to log out and log back in for changes to take effect.
 
 **Note:** Only admins should be able to modify roles. This is typically done through an admin interface or database directly.
 
 ## Troubleshooting Access Issues
 
-| Problem                               | Cause                             | Solution                                |
-| ------------------------------------- | --------------------------------- | --------------------------------------- |
-| "Only Chair/Board members can access" | User not in chair division        | Contact admin to update role            |
-| "You must be logged in"               | Session expired                   | Log in again                            |
-| Create button not visible             | Not a planner or still loading    | Wait for profile to load, or check role |
-| Export button not visible             | Not in list view or not a planner | Switch to list view, verify role        |
+| Problem                                        | Cause                                              | Solution                                  |
+| ---------------------------------------------- | -------------------------------------------------- | ----------------------------------------- |
+| "Only Chair/Board members or heads can access" | User not planner (no chair division, not isHeadOf) | Contact admin to set division or isHeadOf |
+| "You must be logged in"                        | Session expired                                    | Log in again                              |
+| Create button not visible                      | Not a planner or still loading                     | Wait for profile to load, or check role   |
+| Export button not visible                      | Not in list view or not a planner                  | Switch to list view, verify role          |
 
 ## Related Documentation
 
 - [Workflow](./workflow.md) - How to use shift planning features
 - [CSV Format](./csv-format.md) - Export format specification
 - [API Reference](./api-reference.md) - Technical endpoint details
-- [Authentication](../api/authentication.md) - General auth documentation
+- [Authentication](../guides/flows/login-flow.md) - General auth documentation

--- a/.docs/shifts/role-access.md
+++ b/.docs/shifts/role-access.md
@@ -1,0 +1,285 @@
+# Role-Based Access Control
+
+How access to shift planning is controlled and who can perform which actions.
+
+## Overview
+
+Shift planning functionality is restricted to **Chair and Board members** only. This ensures that only authorized personnel can create, modify, and export shift data for Q-Summit 2026.
+
+## Role Hierarchy
+
+```
+┌─────────────────────────────────────┐
+│           Chair/Board               │  ← Full shift planning access
+│         (division = "chair")          │
+└─────────────────────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────┐
+│         Other Divisions             │  ← Read-only access (view shifts)
+│    (operations, marketing, etc.)    │
+└─────────────────────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────┐
+│           Not Logged In             │  ← No access (redirected to login)
+└─────────────────────────────────────┘
+```
+
+## Planner Role
+
+### Who is a Planner?
+
+A user is considered a **planner** if:
+
+1. They are logged in (authenticated)
+2. Their profile has `division === "chair"`
+
+This includes:
+
+- **Chairman**: The event chair
+- **Board Members**: Members of the organizing board
+
+### How the Role is Checked
+
+The `useIsPlanner` hook checks the user's profile:
+
+```typescript
+// src/lib/use-is-planner.ts
+export function useIsPlanner(): { isPlanner: boolean; isLoading: boolean } {
+  const { data, isLoading } = api.profile.getMy.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const isPlanner = data?.profile?.division === "chair";
+
+  return { isPlanner, isLoading };
+}
+```
+
+This hook is used in components to conditionally show planner-only features.
+
+## Access Matrix
+
+| Feature                    | Chair/Board | Other Divisions | Not Logged In |
+| -------------------------- | ----------- | --------------- | ------------- |
+| **View Shifts (List)**     | ✅ Yes      | ✅ Yes          | ❌ No         |
+| **View Shifts (Calendar)** | ✅ Yes      | ✅ Yes          | ❌ No         |
+| **Create Shift**           | ✅ Yes      | ❌ No           | ❌ No         |
+| **Edit Shift**             | ✅ Yes      | ❌ No           | ❌ No         |
+| **Delete Shift**           | ✅ Yes      | ❌ No           | ❌ No         |
+| **Export CSV**             | ✅ Yes      | ❌ No           | ❌ No         |
+
+## API-Level Protection
+
+### Procedure Types
+
+The tRPC router uses different procedure types to enforce access control:
+
+| Procedure            | Authentication | Authorization          | Use Case                          |
+| -------------------- | -------------- | ---------------------- | --------------------------------- |
+| `publicProcedure`    | None           | None                   | Public data (not used for shifts) |
+| `protectedProcedure` | Required       | None                   | Authenticated users can access    |
+| `plannerProcedure`   | Required       | `division === "chair"` | Planners only                     |
+
+### Protected Endpoints
+
+**Planner-only endpoints** (require `plannerProcedure`):
+
+```typescript
+// shiftRouter
+{
+  create: plannerProcedure,      // Create new shifts
+  update: plannerProcedure,      // Edit existing shifts
+  delete: plannerProcedure,      // Delete shifts
+  exportCsv: plannerProcedure,   // Export CSV data
+}
+```
+
+**Authenticated endpoints** (require `protectedProcedure`):
+
+```typescript
+// shiftRouter
+{
+  getById: protectedProcedure,   // View single shift
+  list: protectedProcedure,      // List all shifts
+  calendar: protectedProcedure,    // Calendar view data
+}
+```
+
+### Middleware Implementation
+
+The `plannerProcedure` uses middleware to enforce access:
+
+```typescript
+// src/server/api/trpc.ts
+const plannerMiddleware = t.middleware(async ({ ctx, next }) => {
+  // Check authentication
+  if (!ctx?.session?.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "You must be logged in to perform this action",
+    });
+  }
+
+  const userId = ctx.session.user.id;
+
+  // Get user's profile
+  const profile = await ctx.db.query.memberProfile.findFirst({
+    where: eq(memberProfile.userId, userId),
+  });
+
+  // Check division
+  if (profile?.division !== "chair") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only Chair/Board members can access shift planning",
+    });
+  }
+
+  return next({ ctx });
+});
+
+export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);
+```
+
+## UI-Level Protection
+
+### Conditional Rendering
+
+UI components check the planner role before showing controls:
+
+```typescript
+// In ShiftManager component
+const { data: profileData, isLoading: isProfileLoading } = api.profile.getMy.useQuery(...);
+const isPlanner = profileData?.profile?.division === "chair";
+
+// Only show Create button to planners
+{isPlanner && (
+  <Button onClick={() => setIsCreateModalOpen(true)}>
+    <Plus className="h-4 w-4" />
+    Create
+  </Button>
+)}
+
+// Only show Export button to planners (and only in list view)
+{isPlanner && viewMode === "list" && <CsvExportButton />}
+```
+
+### What Non-Planners See
+
+Non-planners accessing the shifts page see:
+
+- ✅ List of all shifts
+- ✅ Calendar view with shift distribution
+- ✅ Shift details (location, task, time, headcount)
+- ❌ No "Create" button
+- ❌ No "Edit" or "Delete" actions
+- ❌ No "Export" button
+
+## Error Handling
+
+### API Errors
+
+When a non-planner tries to access planner-only endpoints:
+
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "Only Chair/Board members can access shift planning"
+  }
+}
+```
+
+When an unauthenticated user tries to access any shift endpoint:
+
+```json
+{
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "You must be logged in to perform this action"
+  }
+}
+```
+
+### UI Feedback
+
+- **Create button hidden**: Non-planners don't see the button at all
+- **Export button hidden**: Only visible in list view to planners
+- **Error banners**: Show if data fails to load due to permissions
+
+## Security Considerations
+
+### Defense in Depth
+
+Access control is enforced at multiple layers:
+
+1. **UI Layer**: Buttons hidden from non-planners
+2. **API Layer**: Middleware rejects unauthorized requests
+3. **Database Layer**: No direct access; all queries go through API
+
+### Why Not Just UI-Level?
+
+Hiding buttons in the UI is not enough because:
+
+- Users could inspect network requests
+- Direct API calls bypass the UI
+- Security must be enforced server-side
+
+### Session Validation
+
+Every API request validates the session:
+
+```typescript
+const session = await auth.api.getSession({ headers: opts.headers });
+```
+
+Sessions are:
+
+- Encrypted and tamper-proof
+- Validated on every request
+- Expire after a period of inactivity
+
+## Changing Roles
+
+### How Roles Are Assigned
+
+Roles are stored in the `memberProfile` table:
+
+| Column     | Type   | Description                                 |
+| ---------- | ------ | ------------------------------------------- |
+| `userId`   | string | Link to user account                        |
+| `division` | string | Role/division ("chair", "operations", etc.) |
+
+### Updating a User's Role
+
+To grant planner access:
+
+1. Update the user's profile in the database:
+
+```sql
+UPDATE member_profile
+SET division = 'chair'
+WHERE user_id = 'user-uuid-here';
+```
+
+2. The user must log out and log back in for changes to take effect
+
+**Note:** Only admins should be able to modify roles. This is typically done through an admin interface or database directly.
+
+## Troubleshooting Access Issues
+
+| Problem                               | Cause                             | Solution                                |
+| ------------------------------------- | --------------------------------- | --------------------------------------- |
+| "Only Chair/Board members can access" | User not in chair division        | Contact admin to update role            |
+| "You must be logged in"               | Session expired                   | Log in again                            |
+| Create button not visible             | Not a planner or still loading    | Wait for profile to load, or check role |
+| Export button not visible             | Not in list view or not a planner | Switch to list view, verify role        |
+
+## Related Documentation
+
+- [Workflow](./workflow.md) - How to use shift planning features
+- [CSV Format](./csv-format.md) - Export format specification
+- [API Reference](./api-reference.md) - Technical endpoint details
+- [Authentication](../api/authentication.md) - General auth documentation

--- a/.docs/shifts/workflow.md
+++ b/.docs/shifts/workflow.md
@@ -1,0 +1,192 @@
+# Shift Planning Workflow
+
+How to create and manage volunteer shifts for Q-Summit 2026.
+
+## Prerequisites
+
+- You must be logged in with a Chair or Board role (division = "chair")
+- Access the shift planning page via the main navigation
+
+## Creating a New Shift
+
+### Step 1: Open the Create Form
+
+1. Navigate to the Shifts page
+2. Click the **Create** button (visible only to planners)
+3. The shift creation modal opens
+
+### Step 2: Enter Basic Information
+
+| Field    | Required | Description                                                          |
+| -------- | -------- | -------------------------------------------------------------------- |
+| Location | Yes      | Where the shift takes place (e.g., "Main Hall", "Registration Desk") |
+| Task     | Yes      | Brief description of the work (e.g., "Registration Check-in")        |
+
+### Step 3: Set Time Schedule
+
+| Field      | Required | Description                                    |
+| ---------- | -------- | ---------------------------------------------- |
+| Start Time | Yes      | When the shift begins (30-minute increments)   |
+| End Time   | Yes      | When the shift ends (must be after start time) |
+
+**Time Slot Rules:**
+
+- Times must be on 30-minute boundaries (e.g., 09:00, 09:30, 10:00)
+- The system automatically generates 30-minute slots between start and end times
+- Each slot starts with 0 headcount and can be customized
+
+### Step 4: Configure Headcount per Slot
+
+By default, all slots have 0 headcount. To customize:
+
+1. Pass slot data when creating via API, or
+2. The system creates slots automatically with 0 headcount
+
+Each slot represents a 30-minute window where volunteers are needed.
+
+### Step 5: Select Required Skills
+
+Choose skills from the categorized talent list:
+
+- Skills are grouped by category (e.g., "Technical", "Logistics", "Communication")
+- Select all that apply
+- These help match volunteers to appropriate shifts
+
+### Step 6: Select Required Tools
+
+Available tool options:
+
+| Tool      | Description                              |
+| --------- | ---------------------------------------- |
+| Car       | Volunteer needs a car for transportation |
+| Van       | Volunteer needs a van                    |
+| Equipment | Special equipment required               |
+| None      | No special tools needed                  |
+
+### Step 7: Add Documentation (Optional)
+
+| Field       | Description                              |
+| ----------- | ---------------------------------------- |
+| Notion Link | Link to detailed documentation in Notion |
+| Description | Additional details about the shift       |
+
+**Notion URL Validation:**
+
+- Must be a valid URL
+- Must be on notion.so domain (or subdomain)
+
+### Step 8: Submit
+
+1. Review all fields
+2. Click **Create Shift**
+3. The modal closes and the shift appears in the list/calendar
+
+## Managing Existing Shifts
+
+### Viewing Shifts
+
+Two view modes are available:
+
+**List View:**
+
+- Shows all shifts in a scrollable list
+- Displays location, task, time range, and total headcount
+- Supports filtering by location and date range
+
+**Calendar View:**
+
+- Shows shifts by day (April 9-10, 2026)
+- Groups shifts by hour
+- Shows volunteer count per time slot
+- Navigate between days with arrow buttons
+
+### Editing a Shift
+
+1. Find the shift in list or calendar view
+2. Click to open the shift details
+3. Modify fields as needed
+4. Save changes
+
+**Note:** Updating a shift replaces all slots, skills, and tools. The previous data is deleted and recreated.
+
+### Deleting a Shift
+
+1. Locate the shift you want to remove
+2. Use the delete action (requires planner role)
+3. Confirm deletion
+4. The shift and all associated slots are permanently removed
+
+## Exporting Shift Data
+
+### CSV Export
+
+Planners can export all shift data to CSV:
+
+1. Switch to **List View** (export is available here)
+2. Click the **Export** button
+3. The CSV file downloads automatically
+
+**Export Contents:**
+
+- All shifts with their slots
+- Skills and tools for each shift
+- Formatted for German Excel compatibility
+
+See [CSV Format](./csv-format.md) for detailed format specification.
+
+## Workflow Diagram
+
+```mermaid
+sequenceDiagram
+    actor Planner
+    participant UI as Shift Manager
+    participant API as tRPC API
+    participant DB as Database
+
+    Planner->>UI: Click "Create"
+    UI->>Planner: Show Create Modal
+    Planner->>UI: Fill Form (location, task, times, skills, tools)
+    UI->>UI: Validate (30-min boundaries, end > start)
+    Planner->>UI: Submit
+    UI->>API: shift.create()
+    API->>API: Validate input (Zod schema)
+    API->>API: Build slots (30-min intervals)
+    API->>DB: Transaction: insert shift + slots + skills + tools
+    DB-->>API: Success
+    API-->>UI: { ok: true, id: "uuid" }
+    UI->>UI: Close modal, refresh list
+    UI-->>Planner: Show new shift
+
+    Planner->>UI: Switch to Calendar view
+    UI->>API: shift.calendar({ date })
+    API->>DB: Query slots for date
+    DB-->>API: Slot data with shift details
+    API-->>UI: Grouped by time slot
+    UI-->>Planner: Display calendar grid
+
+    Planner->>UI: Click Export
+    UI->>API: shift.exportCsv()
+    API->>DB: Query all shifts + slots + skills + tools
+    DB-->>API: Raw data
+    API->>API: Format CSV (semicolon delimited)
+    API-->>UI: { csv: "..." }
+    UI->>UI: Trigger file download
+    UI-->>Planner: File downloaded
+```
+
+## Best Practices
+
+1. **Be Specific**: Use clear location names and task descriptions
+2. **Plan Ahead**: Create shifts well before the event
+3. **Document**: Link to Notion pages for complex tasks
+4. **Review**: Check calendar view to spot scheduling conflicts
+5. **Export Regularly**: Keep backups of shift data
+
+## Troubleshooting
+
+| Issue                                 | Solution                                          |
+| ------------------------------------- | ------------------------------------------------- |
+| "End time must be after start time"   | Ensure end time is later than start time          |
+| "Must be on 30-minute boundary"       | Round times to nearest 30 minutes (:00 or :30)    |
+| "Only Chair/Board members can access" | Contact an admin to get planner permissions       |
+| Export button not visible             | Switch to List view; only planners see the button |

--- a/.docs/shifts/workflow.md
+++ b/.docs/shifts/workflow.md
@@ -4,7 +4,7 @@ How to create and manage volunteer shifts for Q-Summit 2026.
 
 ## Prerequisites
 
-- You must be logged in with a Chair or Board role (division = "chair")
+- You must be logged in with planner access (Chair/Board role or `isHeadOf = true`)
 - Access the shift planning page via the main navigation
 
 ## Creating a New Shift

--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -1,0 +1,7 @@
+{
+  "active_plan": "/home/lukas/.fulcrum/worktrees/github-issue-9-oa7o/.sisyphus/plans/shift-planning.md",
+  "started_at": "2026-03-13T21:01:25.981Z",
+  "session_ids": ["ses_317568311ffegbjHwNd5letu1L"],
+  "plan_name": "shift-planning",
+  "agent": "atlas"
+}

--- a/.sisyphus/notepads/shift-planning/decisions.md
+++ b/.sisyphus/notepads/shift-planning/decisions.md
@@ -1,0 +1,5 @@
+## 2026-03-13
+
+- Added `isHeadOf` directly on Better Auth `user` table as a boolean (`integer` with `mode: "boolean"`, default `false`) to keep role metadata colocated with auth identity for upcoming planner checks.
+- Modeled shift planning with separate normalized tables: `shifts`, `shift_slots`, `shift_skills`, `shift_tools`.
+- Used explicit named indexes for expected query paths: `shifts.startTime`, `shifts.location`, and `shift_slots.slotTime`.

--- a/.sisyphus/notepads/shift-planning/issues.md
+++ b/.sisyphus/notepads/shift-planning/issues.md
@@ -1,0 +1,23 @@
+## 2026-03-13
+
+- `bun run db:generate` initially failed because migration metadata snapshot `0002_snapshot.json` was in an outdated/incomplete format.
+- After normalizing snapshot metadata shape and removing stale `talent.label` snapshot drift, migration generation proceeded cleanly.
+- agent:finalize currently fails due pre-existing Prettier issues in .sisyphus/boulder.json and .sisyphus/plans/shift-planning.md (not introduced by this task).
+
+## 2026-03-14
+
+- Full integration QA found `bun test` failing with an unhandled `@trpc/server` non-server environment error originating from `src/server/api/trpc.ts` during `src/server/api/routers/__tests__/slack.integration.test.ts`.
+- `bun run agent:finalize` does not pass cleanly because ESLint reports an unused `AlertCircle` import in `src/components/shifts/shift-manager.tsx`.
+- Shift UI composition is incomplete: `src/components/shifts/shift-manager.tsx` renders its own inline list/calendar views instead of using exported `src/components/shifts/shift-list.tsx` and `src/components/shifts/calendar-view.tsx`, so the standalone components are story-covered but not wired into the main flow.
+
+- 2026-03-14 code-quality review: `bun run check` fails lint with unused `AlertCircle` import in `src/components/shifts/shift-manager.tsx`; `bun test` fails because `src/server/api/trpc.ts` initializes `@trpc/server` outside a server environment during tests.
+
+## 2026-03-14 (continued)
+
+- MSW handler fixes complete for shift story files (shift-form, shift-list, calendar-view, shift-manager), but remaining test failures are component-level accessibility violations:
+  - `calendar-view.tsx`: Navigation buttons lack discernible text (icon-only buttons need `aria-label`)
+  - `calendar-view.tsx` & `shift-list.tsx`: Scrollable regions (`.overflow-x-auto`) need keyboard access (`tabindex`)
+  - `shift-form.tsx`: Form inputs not properly associated with `<Label>` components
+  - `shift-manager.tsx`: Heading order violation (`<h3>` without preceding `<h1>` or `<h2>`)
+  - `csv-export-button.tsx`: Icon-only button lacks accessible name
+- Pre-existing Prettier formatting issue in `src/components/shifts/shift-form.tsx` (untracked new file)

--- a/.sisyphus/notepads/shift-planning/learnings.md
+++ b/.sisyphus/notepads/shift-planning/learnings.md
@@ -1,0 +1,245 @@
+## CSV Export Button Implementation - 2026-03-14
+
+### Component Structure
+
+- Created `CsvExportButton` component in `src/components/shifts/csv-export-button.tsx`
+- Follows existing patterns from `shift-form.tsx` and other shift components
+- Uses shadcn/ui `Button` component with `variant="outline"` and `size="sm"`
+- Uses lucide-react icons: `Download` and `Loader2` (with `animate-spin`)
+
+### Key Features Implemented
+
+1. **tRPC Mutation**: Uses `api.shift.exportCsv.useMutation()` to call the export procedure
+2. **File Download**: Creates Blob with UTF-8 BOM (`"\uFEFF"`) for German Excel compatibility
+3. **Loading State**: Shows `Loader2` spinner with animation while mutation is pending
+4. **Error Handling**: Gracefully handles mutation errors via tRPC error handling
+5. **Custom Filename**: Supports optional `filename` prop (defaults to "shifts-export.csv")
+6. **Responsive**: Shows "Export" text on larger screens only (`hidden sm:inline`)
+
+### TypeScript Patterns
+
+- Props interface with optional `filename` parameter
+- Uses `useMutation` hook with `onSuccess` callback for download
+- Proper type inference from tRPC router
+
+### Storybook Stories
+
+Created comprehensive stories in `csv-export-button.stories.tsx`:
+
+- `Default`: Button ready to export with mock CSV data
+- `Loading`: Shows spinner during export (simulated slow network)
+- `Success`: Export completed successfully
+- `Error`: Server error response handling
+- `EmptyExport`: CSV with header only (no shifts)
+- `CustomFilename`: Uses custom download filename
+
+### MSW Integration
+
+- Used `trpcMutation` helper from `.storybook/utils/trpc-helpers`
+- Mock CSV data with semicolon delimiter matching server format
+- Error state uses raw `http.post` handler for tRPC error response
+- Loading state simulates slow network with 100s delay
+
+### CSV Format
+
+- Semicolon delimiter for German Excel compatibility
+- UTF-8 BOM prefix (`"\uFEFF"`) for proper character encoding
+- Header row: `shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link`
+- ISO datetime format with space separator (not T)
+- Skills/tools joined with commas within cells
+
+### UI Patterns Followed
+
+- Outline button variant for secondary action
+- Small size for header placement
+- Gap between icon and text
+- Disabled state during loading
+- Consistent with existing shift component styling
+
+## Full Integration QA - 2026-03-14
+
+- `src/server/api/root.ts` registers `shift: shiftRouter`, so the router is exposed through the app router.
+- `src/domain/qsum/shifts/index.ts` re-exports `constants`, `types`, and `validation`, and `src/server/api/routers/shift.ts` consumes those exports directly.
+- All required shift UI files and Storybook stories exist, and each story imports its paired component successfully.
+- The main `/shifts` flow currently queries `api.shift.list` and `api.shift.calendar` inside `src/components/shifts/shift-manager.tsx`, but does not compose the exported `ShiftList` and external `CalendarView` components.
+
+## CSV Export Button Implementation - 2026-03-14
+
+### Component Structure
+
+- Created `CsvExportButton` component in `src/components/shifts/csv-export-button.tsx`
+- Follows existing patterns from `shift-form.tsx` and other shift components
+- Uses shadcn/ui `Button` component with `variant="outline"` and `size="sm"`
+- Uses lucide-react icons: `Download` and `Loader2` (with `animate-spin`)
+
+### Key Features Implemented
+
+1. **tRPC Mutation**: Uses `api.shift.exportCsv.useMutation()` to call the export procedure
+2. **File Download**: Creates Blob with UTF-8 BOM (`"\uFEFF"`) for German Excel compatibility
+3. **Loading State**: Shows `Loader2` spinner with animation while mutation is pending
+4. **Error Handling**: Gracefully handles mutation errors via tRPC error handling
+5. **Custom Filename**: Supports optional `filename` prop (defaults to "shifts-export.csv")
+6. **Responsive**: Shows "Export" text on larger screens only (`hidden sm:inline`)
+
+### TypeScript Patterns
+
+- Props interface with optional `filename` parameter
+- Uses `useMutation` hook with `onSuccess` callback for download
+- Proper type inference from tRPC router
+
+### Storybook Stories
+
+Created comprehensive stories in `csv-export-button.stories.tsx`:
+
+- `Default`: Button ready to export with mock CSV data
+- `Loading`: Shows spinner during export (simulated slow network)
+- `Success`: Export completed successfully
+- `Error`: Server error response handling
+- `EmptyExport`: CSV with header only (no shifts)
+- `CustomFilename`: Uses custom download filename
+
+### MSW Integration
+
+- Used `trpcMutation` helper from `.storybook/utils/trpc-helpers`
+- Mock CSV data with semicolon delimiter matching server format
+- Error state uses raw `http.post` handler for tRPC error response
+- Loading state simulates slow network with 100s delay
+
+### CSV Format
+
+- Semicolon delimiter for German Excel compatibility
+- UTF-8 BOM prefix (`"\uFEFF"`) for proper character encoding
+- Header row: `shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link`
+- ISO datetime format with space separator (not T)
+- Skills/tools joined with commas within cells
+
+### UI Patterns Followed
+
+- Outline button variant for secondary action
+- Small size for header placement
+- Gap between icon and text
+- Disabled state during loading
+- Consistent with existing shift component styling
+
+## Documentation Created - 2026-03-14
+
+Created comprehensive documentation for the Shift Planning feature in `.docs/shifts/`:
+
+### Files Created
+
+1. **README.md** - Overview and navigation hub
+   - Feature summary
+   - Quick links to all docs
+   - Data model ER diagram
+   - Cross-references to related docs
+
+2. **workflow.md** - User workflow documentation
+   - Step-by-step shift creation guide
+   - View modes (list vs calendar)
+   - Editing and deleting shifts
+   - CSV export workflow
+   - Sequence diagram showing full workflow
+   - Best practices and troubleshooting
+
+3. **csv-format.md** - CSV export specification
+   - UTF-8 BOM encoding for German Excel
+   - Semicolon delimiter format
+   - Column structure and examples
+   - DateTime formatting (ISO with space)
+   - Skills/tools comma-separated format
+   - Usage instructions for Excel and Google Sheets
+   - Code examples for Python and JavaScript
+
+4. **role-access.md** - Access control documentation
+   - Role hierarchy (Chair/Board vs others)
+   - Access matrix for all features
+   - API-level protection (plannerProcedure)
+   - UI-level conditional rendering
+   - Security considerations
+   - Troubleshooting access issues
+
+5. **api-reference.md** - Technical API documentation
+   - All 7 endpoints documented
+   - Input/output schemas with examples
+   - Validation rules and error codes
+   - React hook usage patterns
+   - Domain type definitions
+
+### Documentation Patterns Used
+
+- Mermaid diagrams for workflows and ER diagrams
+  - Sequence diagrams for user flows
+  - ER diagram for data model
+- Consistent structure following DOCUMENTATION_GUIDE.md
+- Cross-references between related documents
+- Practical examples throughout
+- Tables for structured data (access matrix, column specs)
+
+### Key Technical Details Documented
+
+- 30-minute time slot granularity
+- Semicolon-delimited CSV for German Excel
+- UTF-8 BOM for proper character encoding
+- Role check: `division === "chair"`
+- tRPC procedure types and middleware
+- Zod validation schemas
+- Error codes and handling
+
+- 2026-03-14 shift review: shift files are largely free of `as any`, TS suppression, empty catches, and commented-out code; notable findings are server-side `console.log` usage in `src/server/api/trpc.ts` and story-only `console.log` callbacks in `src/components/shifts/shift-list.stories.tsx`.
+
+## MSW Handler Fixes for Storybook Stories - 2026-03-14
+
+### Problem
+
+Storybook stories for shift components were failing with:
+
+1. "Query data cannot be undefined" - React Query v5 requires query functions to return a value
+2. "MSW Warning: intercepted a request without a matching request handler" for `profile.getMy`, `shift.list`, etc.
+
+### Solution Pattern
+
+Created base handler factories that provide ALL endpoints a component uses:
+
+```typescript
+const createBaseHandlers = () => [
+  trpcQuery("profile", "getMy", () => ({
+    user: { name: "Test User", image: null },
+    profile: { division: "chair", team: "executive", role: "Planner" },
+  })),
+  trpcQuery("shift", "list", () => ({ items: [], total: 0, nextCursor: null })),
+  trpcQuery("shift", "calendar", () => []),
+];
+```
+
+### Key Insight
+
+Components often call multiple tRPC endpoints even when testing a single feature. Stories must mock ALL endpoints a component uses:
+
+- `ShiftManager` calls `profile.getMy`, `shift.list`, and `shift.calendar` depending on view mode
+- `ShiftForm` calls `profile.getMy` for user context and `profile.listTalents` for dropdown
+- `CalendarView` calls `shift.calendar` for data and `profile.getMy` for permissions
+
+### Files Updated
+
+1. `shift-form.stories.tsx`: Added `createBaseHandlers()` to all 6 stories
+2. `shift-list.stories.tsx`: Added `createBaseHandlers()` to all 10 stories
+3. `calendar-view.stories.tsx`: Added `createCalendarHandlers()` factory to all 10 stories
+4. `shift-manager.stories.tsx`: Added missing `shift.list` handlers to 5 stories
+
+### Results
+
+| Story File                | Before | After       |
+| ------------------------- | ------ | ----------- |
+| shift-form.stories.tsx    | 0/6    | 6/6         |
+| shift-list.stories.tsx    | 0/10   | 10/10       |
+| shift-manager.stories.tsx | 10/11  | 10/11       |
+| calendar-view.stories.tsx | 0/10   | 1/10 (a11y) |
+
+### Remaining A11y Issues (Component-Level)
+
+- Icon-only buttons missing `aria-label` (button-name rule)
+- Scrollable regions missing `tabindex` (scrollable-region-focusable rule)
+- Form inputs not properly associated with labels
+- Heading order violations (h3 without preceding h1/h2)
+
+These require component code changes, not story file changes.

--- a/.sisyphus/plans/shift-planning.md
+++ b/.sisyphus/plans/shift-planning.md
@@ -1,0 +1,1014 @@
+# Shift Planning System for Q-Summit
+
+## TL;DR
+
+> **Quick Summary**: Headcount planning system for Q-Summit 2026 (April 9-10). Allows planners to create shifts with time slots, define how many people needed per 30-min slot, and visualize demand spikes in a calendar view.
+
+> **Deliverables**:
+>
+> - Shift CRUD (create, read, update, delete)
+> - Time slot management with per-slot headcount
+> - List view with sortable table and inline editing
+> - Calendar view (daily/hourly) showing demand
+> - Skills from existing talent table
+> - Basic tools list
+> - CSV export (semicolon delimiter for German Excel)
+> - Role-based access control (Chair + Board only)
+
+> **Estimated Effort**: Medium-Large
+> **Parallel Execution**: YES - 4 waves
+> **Critical Path**: Schema → Domain → Router → List View → Calendar View → Export
+
+---
+
+## Context
+
+### Original Request (GitHub Issue #9)
+
+Planning team needs ability to create shifts with:
+
+- Location (where)
+- Task/Role (what)
+- People needed (how many)
+- Duration (start-end time)
+- Skills required (reuse talent)
+- Tools needed (car, etc.)
+- Notion link
+- Free text description
+
+### User Clarifications
+
+- **Headcount planning ONLY** - not assigning actual people yet (later: rule engine)
+- **30-minute granularity** - can specify different counts per slot (e.g., 6 people 8-22, but 0 from 12-14)
+- **Calendar**: daily view, hour-by-hour to see demand spikes
+- **Roles**: isHeadOf flag on user table (team leads marked by Board/Chairs)
+- **Skills**: Reuse existing talent table
+- **Locations**: Freeform (planners create as needed)
+- **Tools**: Basic list (car, van, equipment)
+- **Export**: CSV needed (semicolon delimiter for German Excel)
+- **Dates**: Hardcoded Q-Summit (April 9-10, 2026)
+
+### Role Hierarchy (CONFIRMED)
+
+| Role        | division   | isHeadOf | Can Access Shift Planning? |
+| ----------- | ---------- | -------- | -------------------------- |
+| Chairman    | 'chair'    | any      | YES                        |
+| Board       | 'chair'    | true     | YES                        |
+| Head Of     | != 'chair' | true     | NO (reports to Board)      |
+| Team Member | any        | false    | NO                         |
+
+**Access Rule**: Only `member_profile.division === 'chair'` can access shift planning. This includes both the Chairman and Board members (who have division='chair').
+
+---
+
+## Work Objectives
+
+### Core Objective
+
+Enable Q-Summit planners (Chair + Board only) to define shift time slots with headcount requirements, visualize demand across the day, and export for sharing.
+
+### Concrete Deliverables
+
+- [ ] Shift creation form with: location, task, duration, skills, tools, Notion link, description
+- [ ] Time slot management (30-min granularity with per-slot headcount)
+- [ ] List view: sortable table with inline editing
+- [ ] Calendar view: daily/hourly grid showing headcount per slot
+- [ ] CSV export: all slots with details (semicolon delimiter)
+- [ ] Role access control: Chair + Board only
+
+### Definition of Done
+
+- [ ] `bun test` passes for all shift router tests
+- [ ] Calendar renders correctly for April 9-10, 2026
+- [ ] CSV export parses correctly with semicolon delimiter
+- [ ] Only Chair/Board can create/update/delete shifts
+
+### Must Have
+
+- 30-minute time slot boundaries (09:00, 09:30, not 09:15)
+- Per-slot headcount (0-N people per slot)
+- Skills from talent table
+- Basic tools dropdown
+- Notion URL field
+- Division-based planner access (division === 'chair')
+
+### Must NOT Have (Guardrails)
+
+- ❌ Person assignment (later: rule engine)
+- ❌ Real-time updates (SSE/WebSocket)
+- ❌ Recurring shifts
+- ❌ Shift templates/duplication
+- ❌ Conflict detection
+- ❌ Audit trail
+- ❌ Soft deletes (hard delete only)
+- ❌ Multi-event support (Q-Summit only)
+
+---
+
+## Verification Strategy
+
+**ZERO HUMAN INTERVENTION** — ALL verification is agent-executed. No exceptions.
+
+### Test Decision
+
+- **Infrastructure exists**: YES (bun test, vitest for components)
+- **Automated tests**: TDD (test-first approach)
+- **Framework**: bun test + vitest (via Storybook)
+- **TDD Workflow**: RED (failing test) → GREEN (minimal impl) → REFACTOR
+
+### QA Policy
+
+Every task MUST include agent-executed QA scenarios. Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Backend Tests**: Use `bun test` for tRPC router tests
+- **Frontend**: Use Playwright for E2E
+- **Components**: Use Storybook with play functions
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Foundation - can run in parallel):
+├── Task 1: Database Schema (shifts, shift_slots, shift_skills, shift_tools, isHeadOf on user)
+├── Task 2: Domain Layer (types, constants, validation)
+├── Task 3: tRPC Router Skeleton (registered in root.ts)
+└── Task 4: Planner Role Middleware (depends on Task 1 - needs isHeadOf field)
+
+Wave 2 (Backend - can run in parallel):
+├── Task 5: Shift CRUD procedures with tests
+├── Task 6: List query with sorting/filtering
+├── Task 7: Calendar query for demand visualization
+└── Task 8: CSV export procedure
+
+Wave 3 (Frontend - can run in parallel):
+├── Task 9: Shift creation form (Modal or page)
+├── Task 10: List view with inline editing
+├── Task 11: Calendar view (daily/hourly)
+└── Task 12: CSV export button + download
+
+Wave 4 (Integration + Polish):
+├── Task 13: Connect views to tRPC
+├── Task 14: Role enforcement (API + UI)
+├── Task 15: Edge case handling
+└── Task 16: Documentation
+
+Wave FINAL (Verification):
+├── Task F1: Plan Compliance Audit
+├── Task F2: Code Quality Review
+├── Task F3: Full integration QA
+└── Task F4: Scope Fidelity Check
+```
+
+### Dependency Matrix
+
+| Task       | Depends On    | Blocks        |
+| ---------- | ------------- | ------------- |
+| 1          | -             | 2, 3, 4, 5-8  |
+| 2          | 1             | 4             |
+| 3          | 1             | 4             |
+| 4          | 1, 2, 3       | 5, 6, 7, 8    |
+| 5, 6, 7, 8 | 4             | 9, 10, 11, 12 |
+| 9, 10, 11  | 5, 6, 7, 8    | 13            |
+| 12         | 8             | 13            |
+| 13         | 9, 10, 11, 12 | 14, 15, 16    |
+| 14, 15, 16 | 13            | F1-F4         |
+
+---
+
+## TODOs
+
+### Task 1: Database Schema
+
+**What to do**:
+
+- Create Drizzle tables in `src/server/db/schema.ts`:
+  - `shifts`: id, location, task, description, notionLink, startTime, endTime, createdBy, createdAt
+  - `shift_slots`: id, shiftId, slotTime (30-min boundary), headcount (0-N)
+  - `shift_skills`: id, shiftId, talentId (reuses talent table)
+  - `shift_tools`: id, shiftId, tool (enum: car, van, equipment, none)
+- Add to `user` table (better-auth):
+  - `isHeadOf`: boolean default false (marks team leads)
+- Add indexes: shift.startTime, shift.location, shift_slots.slotTime
+- Run `bun run db:generate` and create migration
+
+**Must NOT do**:
+
+- No assignment columns (out of scope)
+- No soft deletes
+- No recurrence fields
+
+**Recommended Agent Profile**:
+
+- **Category**: `deep` - Schema design requires understanding of temporal data, relationships
+- **Skills**: [`tdd`]
+
+**Parallelization**: Wave 1 (with Tasks 2, 3, 4)
+
+**References**:
+
+- `src/server/db/schema.ts` - Existing schema patterns
+- `src/domain/qsum/profile/validation.ts` - Zod validation patterns
+
+**Acceptance Criteria**:
+
+- [x] `bun run db:generate` creates migration file
+- [x] `bun run db:push` applies migration without errors
+- [x] Schema includes all required fields with correct types
+- [x] user table has isHeadOf boolean field
+- [ ] `bun run db:push` applies migration without errors
+- [ ] Schema includes all required fields with correct types
+- [ ] user table has isHeadOf boolean field
+
+**QA Scenarios**:
+
+```
+Scenario: Migration applies cleanly
+  Tool: Bash
+  Preconditions: Fresh database or test DB
+  Steps: 1. Run `bun run db:generate` 2. Run `bun run db:push` 3. Inspect output for errors
+  Expected Result: Migration applies, no errors
+  Evidence: .sisyphus/evidence/task-1-migration.log
+```
+
+---
+
+### Task 2: Domain Layer
+
+**What to do**:
+
+- Create `src/domain/qsum/shifts/`:
+  - `types.ts`: Shift, ShiftSlot, ShiftSkill, ShiftTool interfaces
+  - `constants.ts`: TOOL_OPTIONS, DEFAULT_SHIFT_DURATION
+  - `validation.ts`: ShiftCreateSchema, ShiftUpdateSchema, normalizeShiftInput
+- Follow existing profile domain pattern exactly
+
+**Must NOT do**:
+
+- No business logic (only types, constants, validation)
+- No database imports
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Following established patterns
+
+**Parallelization**: Wave 1 (with Tasks 1, 3, 4)
+
+**References**:
+
+- `src/domain/qsum/profile/types.ts` - Pattern to follow
+- `src/domain/qsum/profile/validation.ts` - Zod schema patterns
+
+**Acceptance Criteria**:
+
+- [x] `bun run typecheck` passes
+- [x] Domain exports all types/constants from index.ts
+- [ ] Domain exports all types/constants from index.ts
+
+**QA Scenarios**:
+
+```
+Scenario: Types compile without errors
+  Tool: Bash
+  Preconditions: Domain files created
+  Steps: 1. Run `bun run typecheck`
+  Expected Result: No TypeScript errors
+  Evidence: .sisyphus/evidence/task-2-typecheck.log
+```
+
+---
+
+### Task 3: tRPC Router Skeleton
+
+**What to do**:
+
+- Create `src/server/api/routers/shift.ts`:
+  - create, getById, update, delete, list, calendar procedures (empty implementations)
+  - Register in `src/server/api/root.ts`
+- Import domain schemas
+- Add protectedProcedure for all
+
+**Must NOT do**:
+
+- No implementation logic yet
+- No public procedures
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Following existing router pattern
+
+**Parallelization**: Wave 1 (with Tasks 1, 2, 4)
+
+**References**:
+
+- `src/server/api/routers/profile.ts` - Router pattern
+- `src/server/api/root.ts` - Registration pattern
+
+**Acceptance Criteria**:
+
+- [x] Router registered in root.ts
+- [x] `bun run build` succeeds
+- [ ] `bun run build` succeeds
+
+**QA Scenarios**:
+
+```
+Scenario: Router builds correctly
+  Tool: Bash
+  Preconditions: Router created
+  Steps: 1. Run `bun run build`
+  Expected Result: Build succeeds
+  Evidence: .sisyphus/evidence/task-3-build.log
+```
+
+---
+
+### Task 4: Planner Role Middleware
+
+**What to do**:
+
+- Add `plannerProcedure` to `src/server/api/trpc.ts`
+- Permission check logic:
+
+  ```typescript
+  const canAccessShiftPlanning = async (ctx: Context) => {
+    const userId = ctx.session.user.id;
+
+    // Get user's profile
+    const profile = await ctx.db.query.memberProfile.findFirst({
+      where: eq(memberProfile.userId, userId),
+    });
+
+    // Chair (division = 'chair') can access - includes Chairman AND Board
+    if (profile?.division === "chair") return true;
+
+    // Everyone else (including Head Of with isHeadOf=true but division != 'chair') cannot access
+    return false;
+  };
+  ```
+
+- Use existing protectedProcedure as base
+- Add isHeadOf field to user table in schema (from Task 1)
+
+**Must NOT do**:
+
+- No super-admin role
+- No cross-division editing (Head Of cannot access - only Chair/Board)
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Simple middleware addition
+
+**Parallelization**: Wave 1 (with Tasks 1, 2, 3)
+
+**References**:
+
+- `src/server/api/trpc.ts` - Existing protectedProcedure
+- `src/lib/auth.ts` - Session handling
+
+**Acceptance Criteria**:
+
+- [x] Non-planner gets error on create attempt
+
+**QA Scenarios**:
+
+```
+Scenario: Role check works correctly
+  Tool: Bash (tRPC caller)
+  Preconditions: Middleware implemented, isHeadOf field added to user table
+  Setup: Seed test users:
+    - chairUser: member_profile.division = 'chair', isHeadOf = false (Chairman)
+    - boardUser: member_profile.division = 'chair', isHeadOf = true (Board)
+    - headOfUser: member_profile.division = 'operations', isHeadOf = true (Head Of - CANNOT access)
+    - regularUser: member_profile.division = 'operations', isHeadOf = false
+  Steps:
+    1. Create mock context with chair user session → call create shift
+    2. Verify SUCCESS
+    3. Create mock context with board user session → call create shift
+    4. Verify SUCCESS
+    5. Create mock context with headOf user session → call create shift
+    6. Verify FORBIDDEN (Head Of cannot access)
+    7. Create mock context with regular user session → call create shift
+    8. Verify FORBIDDEN
+  Expected Result: Chair/Board succeed, HeadOf/Regular get 403
+  Evidence: .sisyphus/evidence/task-4-role-check.log
+```
+
+---
+
+### Task 5: Shift CRUD Procedures
+
+**What to do**:
+
+- Implement create, getById, update, delete in shift router
+- Handle time slot generation (30-min boundaries)
+- Use transactions for slot creation
+- Add input validation from domain
+
+**Must NOT do**:
+
+- No person assignment logic
+- No conflict detection
+
+**Recommended Agent Profile**:
+
+- **Category**: `deep` - Complex transactions for slot management
+
+**Parallelization**: Wave 2 (with Tasks 6, 7, 8)
+
+**References**:
+
+- `src/server/api/routers/profile.ts` - Transaction patterns
+
+**Acceptance Criteria**:
+
+- [x] Create shift generates correct slots
+- [x] Update shifts updates slots correctly
+- [x] Delete removes shift and slots
+- [ ] Update shifts updates slots correctly
+- [ ] Delete removes shift and slots
+
+**QA Scenarios**:
+
+```
+Scenario: Create shift with slots
+  Tool: Bash (tRPC caller)
+  Preconditions: Router implemented
+  Steps: 1. Create shift: start 08:00, end 10:00 2. Query slots for this shift
+  Expected Result: 4 slots (08:00, 08:30, 09:00, 09:30), all with default headcount 0
+  Evidence: .sisyphus/evidence/task-5-create-slots.log
+```
+
+---
+
+### Task 6: List Query with Sorting/Filtering
+
+**What to do**:
+
+- Implement list procedure with:
+  - Sort by: startTime, location, task, createdAt
+  - Filter by: location, date range
+  - Pagination (cursor-based)
+- Include slot summaries (total headcount)
+
+**Must NOT do**:
+
+- No person details (out of scope)
+
+**Recommended Agent Profile**:
+
+- **Category**: `deep` - Complex query with joins
+
+**Parallelization**: Wave 2 (with Tasks 5, 7, 8)
+
+**References**:
+
+- `src/server/api/routers/profile.ts` - List pattern with cursor
+
+**Acceptance Criteria**:
+
+- [x] Returns shifts with pagination
+- [x] Sorting works for all fields
+- [x] Filters work correctly
+- [ ] Sorting works for all fields
+- [ ] Filters work correctly
+
+**QA Scenarios**:
+
+```
+Scenario: List with sorting
+  Tool: Bash (tRPC caller)
+  Preconditions: Multiple shifts exist
+  Steps: 1. Call list with sort: { field: startTime, direction: asc } 2. Verify order
+  Expected Result: Shifts in ascending time order
+  Evidence: .sisyphus/evidence/task-6-list-sort.log
+```
+
+---
+
+### Task 7: Calendar Query
+
+**What to do**:
+
+- Implement calendar procedure:
+  - Input: date (April 9 or 10, 2026)
+  - Output: time slots (30-min) with headcount totals per slot
+  - Group by slotTime, sum headcount
+- Include shift details per slot
+
+**Must NOT do**:
+
+- No person assignment visualization
+
+**Recommended Agent Profile**:
+
+- **Category**: `deep` - Complex aggregation query
+
+**Parallelization**: Wave 2 (with Tasks 5, 6, 8)
+
+**References**:
+
+- `src/server/api/routers/profile.ts` - Query patterns
+
+**Acceptance Criteria**:
+
+- [x] Returns slots for April 9, 2026
+- [x] Returns slots for April 10, 2026
+- [x] Headcount totals correct per slot
+- [ ] Returns slots for April 10, 2026
+- [ ] Headcount totals correct per slot
+
+**QA Scenarios**:
+
+```
+Scenario: Calendar shows demand
+  Tool: Bash (tRPC caller)
+  Preconditions: Shifts with varying headcounts exist
+  Steps: 1. Call calendar for April 9 2. Inspect slot 08:00-08:30
+  Expected Result: Total headcount for that slot
+  Evidence: .sisyphus/evidence/task-7-calendar.log
+```
+
+---
+
+### Task 8: CSV Export Procedure
+
+**What to do**:
+
+- Implement export procedure:
+  - Query all shifts with slots
+  - Generate CSV with columns: shift_id, location, task, start_time, end_time, slot_time, headcount, skills, tools, notion_link
+  - One row per time slot
+  - Semicolon delimiter (German Excel)
+  - UTF-8 with BOM
+
+**Must NOT do**:
+
+- No filtered export (all shifts)
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Straightforward file generation
+
+**Parallelization**: Wave 2 (with Tasks 5, 6, 7)
+
+**Acceptance Criteria**:
+
+- [x] CSV parses correctly in Excel
+- [x] All slots included
+- [x] Correct semicolon format
+- [ ] All slots included
+- [ ] Correct semicolon format
+
+**QA Scenarios**:
+
+```
+Scenario: CSV export parses
+  Tool: Bash
+  Preconditions: Shifts exist
+  Steps: 1. Call export 2. Open in text editor 3. Parse with semicolon delimiter
+  Expected Result: All columns present, correct data
+  Evidence: .sisyphus/evidence/task-8-csv.log
+```
+
+---
+
+### Task 9: Shift Creation Form
+
+**What to do**:
+
+- Create shift form component:
+  - Location (text input, freeform)
+  - Task (text input)
+  - Start/End time pickers
+  - Skills multi-select (from talent table)
+  - Tools dropdown (car, van, equipment)
+  - Notion link (URL input)
+  - Description (textarea)
+- Hook up to tRPC create mutation
+
+**Must NOT do**:
+
+- No person assignment UI
+
+**Recommended Agent Profile**:
+
+- **Category**: `visual-engineering` - Form UI with validation
+
+**Parallelization**: Wave 3 (with Tasks 10, 11, 12)
+
+**References**:
+
+- `src/components/profile/profile-form.tsx` - Form pattern
+- `src/components/ui/` - shadcn components
+
+NP|**Acceptance Criteria**:
+KX|
+
+- [x] Form submits to API
+- [x] Validation errors show
+- [x] Success redirects to list
+- [ ] Storybook story added with MSW for: empty, loading, error states
+      ZX|- [ ] Validation errors show
+      NT|- [ ] Success redirects to list
+      QK|- [ ] Storybook story added with MSW for: empty, loading, error states
+
+WW|**QA Scenarios**:
+
+- [ ] Form submits to API
+- [ ] Validation errors show
+- [ ] Success redirects to list
+
+**QA Scenarios**:
+
+```
+Scenario: Create shift via UI
+  Tool: Playwright
+  Preconditions: Logged in as planner (Chair/Board)
+  Steps: 1. Navigate to /shifts 2. Click "Create Shift" 3. Fill form: location=Test, task=Runner, start=08:00, end=10:00 4. Submit
+  Expected Result: Shift appears in list
+  Evidence: .sisyphus/evidence/task-9-create-form.mp4
+```
+
+---
+
+### Task 10: List View with Inline Editing
+
+**What to do**:
+
+- Create shift list component:
+  - Table with columns: Location, Task, Time, Total Headcount, Skills, Actions
+  - Sortable headers
+  - Inline editing for headcount per slot
+  - Edit/Delete actions
+- Hook to list and update mutations
+
+**Must NOT do**:
+
+- No bulk editing (yet)
+
+**Recommended Agent Profile**:
+
+- **Category**: `visual-engineering` - Complex table with interactions
+
+**Parallelization**: Wave 3 (with Tasks 9, 11, 12)
+
+NP|**Acceptance Criteria**:
+KW|
+JS|- [ ] List loads with shifts
+VT|- [ ] Sorting works
+TJ|- [ ] Inline edit saves
+MX|- [ ] Storybook story added with MSW for: empty, loading, populated, editing states
+
+WW|**QA Scenarios**:
+
+- [ ] List loads with shifts
+- [ ] Sorting works
+- [ ] Inline edit saves
+
+**QA Scenarios**:
+
+```
+Scenario: Inline edit headcount
+  Tool: Playwright
+  Preconditions: Shift exists
+  Steps: 1. Click headcount cell 2. Change value 3. Click outside to save
+  Expected Result: API called, value persisted
+  Evidence: .sisyphus/evidence/task-10-inline-edit.mp4
+```
+
+---
+
+### Task 11: Calendar View (Daily/Hourly)
+
+**What to do**:
+
+- Create calendar component:
+  - Day selector (April 9, April 10)
+  - Y-axis: 30-min time slots (06:00-23:00)
+  - X-axis: Locations OR just show total per slot
+  - Cell shows headcount number
+  - Click slot to see shift details
+- Hook to calendar query
+
+**Must NOT do**:
+
+- No person details in cells
+
+**Recommended Agent Profile**:
+
+- **Category**: `visual-engineering` - Complex visualization
+
+**Parallelization**: Wave 3 (with Tasks 9, 10, 12)
+
+NP|**Acceptance Criteria**:
+KW|
+HB|- [ ] Shows April 9 grid
+VP|- [ ] Shows April 10 grid
+WM|- [ ] Headcount visible per slot
+XB|- [ ] Storybook story added with MSW for: empty, loading, populated, different headcounts
+
+WW|**QA Scenarios**:
+
+- [ ] Shows April 9 grid
+- [ ] Shows April 10 grid
+- [ ] Headcount visible per slot
+
+**QA Scenarios**:
+
+```
+Scenario: Calendar displays demand
+  Tool: Playwright
+  Preconditions: Shifts with headcounts exist
+  Steps: 1. Navigate to calendar view 2. Select April 9
+  Expected Result: Grid shows slots with numbers
+  Evidence: .sisyphus/evidence/task-11-calendar.mp4
+```
+
+---
+
+### Task 12: CSV Export Button
+
+**What to do**:
+
+- Add export button to UI:
+  - Button in list view header
+  - Calls export procedure
+  - Downloads CSV file
+- Show loading state
+
+**Must NOT do**:
+
+- No filtered export options
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Simple button + download
+
+**Parallelization**: Wave 3 (with Tasks 9, 10, 11)
+
+NP|**Acceptance Criteria**:
+WP|
+
+- [x] Button triggers download
+- [x] File contains all data
+- [x] Storybook story added with MSW for: default, loading, success states
+
+WW|**QA Scenarios**:
+
+- [ ] Button triggers download
+- [ ] File contains all data
+
+**QA Scenarios**:
+
+```
+Scenario: Export downloads CSV
+  Tool: Playwright
+  Preconditions: Shifts exist
+  Steps: 1. Click Export CSV button 2. Verify file downloads
+  Expected Result: CSV file with correct content
+  Evidence: .sisyphus/evidence/task-12-export.csv
+```
+
+---
+
+### Task 13: Connect Views to tRPC
+
+**What to do**:
+
+- Wire up all components to API:
+  - List view uses api.shift.list
+  - Calendar uses api.shift.calendar
+  - Form uses api.shift.create/update
+- Add loading states
+- Handle errors gracefully
+
+**Must NOT do**:
+
+- No custom API calls (use tRPC)
+
+**Recommended Agent Profile**:
+
+- **Category**: `visual-engineering` - Integration work
+
+**Parallelization**: After 9, 10, 11
+
+NP|**Acceptance Criteria**:
+TM|
+BB|- [ ] All views work end-to-end
+MX|- [ ] Storybook story for /shifts page with MSW: planner view, non-planner view
+
+WW|**QA Scenarios**:
+
+- [ ] All views work end-to-end
+
+**QA Scenarios**:
+
+```
+Scenario: Full CRUD flow
+  Tool: Playwright
+  Preconditions: Connected
+  Steps: 1. Create shift 2. View in list 3. View in calendar 4. Edit 5. Delete
+  Expected Result: All operations work
+  Evidence: .sisyphus/evidence/task-13-e2e.mp4
+```
+
+---
+
+### Task 14: Role Enforcement (API + UI)
+
+**What to do**:
+
+- Add plannerProcedure to create/update/delete
+- Hide create button for non-planners
+- Show edit/delete only for planners
+- Add error toasts for permission denied
+
+**Must NOT do**:
+
+- No cross-division restrictions
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Middleware + UI tweaks
+
+**Parallelization**: After 13
+
+**Acceptance Criteria**:
+
+- [ ] Non-planner cannot create
+
+**QA Scenarios**:
+
+```
+Scenario: Role enforcement via UI
+  Tool: Playwright
+  Preconditions: Test users seeded
+  Setup: Use browser.storageState() with pre-authenticated sessions
+  Steps:
+    1. Load page with non-planner session
+    2. Verify "Create Shift" button is HIDDEN
+    3. Try direct URL /shifts with non-planner session
+    4. Verify error toast "Permission denied"
+  Expected Result: UI hides create for non-planners
+  Evidence: .sisyphus/evidence/task-14-role-ui.mp4
+
+Scenario: Planner can access
+  Tool: Playwright
+  Preconditions: Planner user seeded
+  Steps:
+    1. Load page with planner session
+    2. Verify "Create Shift" button is VISIBLE
+    3. Create shift succeeds
+  Expected Result: Planner sees full UI
+  Evidence: .sisyphus/evidence/task-14-planner-access.mp4
+```
+
+---
+
+### Task 15: Edge Case Handling
+
+**What to do**:
+
+- Handle edge cases:
+  - Shift spanning midnight (display on both days)
+  - All slots 0 headcount (allow but warn)
+  - Invalid Notion URL (validate format)
+  - Empty shifts list (show empty state)
+- Add validation messages
+
+**Must NOT do**:
+
+- No complex edge case logic
+
+**Recommended Agent Profile**:
+
+- **Category**: `quick` - Bug fixing
+
+**Parallelization**: After 14
+
+**Acceptance Criteria**:
+
+- [ ] Edge cases handled gracefully
+
+**QA Scenarios**:
+
+```
+Scenario: Invalid URL shows error
+  Tool: Playwright
+  Preconditions: None
+  Steps: 1. Enter invalid URL in Notion field 2. Submit form
+  Expected Result: Validation error shown
+  Evidence: .sisyphus/evidence/task-15-validation.mp4
+```
+
+---
+
+### Task 16: Documentation
+
+**What to do**:
+
+- Add docs:
+  - Shift planning workflow
+  - CSV format explanation
+  - Role access explanation
+
+**Must NOT do**:
+
+- No over-documentation
+
+**Recommended Agent Profile**:
+
+- **Category**: `writing` - Documentation
+
+**Acceptance Criteria**:
+
+- [ ] Key workflows documented
+
+**QA Scenarios**:
+
+```
+Scenario: Documentation complete
+  Tool: Bash
+  Preconditions: Documentation written
+  Steps:
+    1. Run `bun run docs:check`
+    2. Verify shift-related docs are flagged for review
+  Expected Result: Docs updated and verified
+  Evidence: .sisyphus/evidence/task-16-docs.log
+```
+
+---
+
+## Final Verification Wave
+
+- [ ] **F1. Plan Compliance Audit** — `oracle`
+      Read the plan end-to-end. For each "Must Have": verify implementation exists. For each "Must NOT Have": search codebase for forbidden patterns. Check evidence files exist.
+      Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+
+- [ ] **F2. Code Quality Review** — `unspecified-high`
+      Run `tsc --noEmit` + linter + `bun test`. Review all changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code.
+      Output: `Build [PASS/FAIL] | Lint [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+
+- [ ] **F3. Full Integration QA** — `unspecified-high` (+ `playwright` skill)
+      Execute EVERY QA scenario from EVERY task. Test cross-task integration. Save to `.sisyphus/evidence/final-qa/`.
+      Output: `Scenarios [N/N pass] | Integration [N/N] | Edge Cases [N tested] | VERDICT`
+
+- [ ] **F4. Scope Fidelity Check** — `deep`
+      For each task: read "What to do", read actual diff. Verify 1:1. Check "Must NOT do" compliance. Detect cross-task contamination.
+      Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | Unaccounted [CLEAN/N files] | VERDICT`
+
+---
+
+## Commit Strategy
+
+- **1**: `feat(shifts): add database schema` — schema.ts, migration
+- **2**: `feat(shifts): add domain types and validation` — domain/shifts/
+- **3**: `feat(shifts): add tRPC router skeleton` — routers/shift.ts
+- **4**: `feat(shifts): add planner role middleware` — trpc.ts
+- **5**: `feat(shifts): implement CRUD operations` — routers/shift.ts (CRUD)
+- **6**: `feat(shifts): add list query` — routers/shift.ts (list)
+- **7**: `feat(shifts): add calendar query` — routers/shift.ts (calendar)
+- **8**: `feat(shifts): add CSV export` — routers/shift.ts (export)
+- **9**: `feat(shifts): add creation form UI` — components/shifts/
+- **10**: `feat(shifts): add list view` — components/shifts/
+- **11**: `feat(shifts): add calendar view` — components/shifts/
+- **12**: `feat(shifts): add CSV export button` — components/shifts/
+- **13**: `feat(shifts): connect UI to API` — integration
+- **14**: `feat(shifts): add role enforcement` — middleware + UI
+- **15**: `fix(shifts): handle edge cases` — edge case handling
+- **16**: `docs(shifts): add documentation` — docs/
+
+---
+
+## Success Criteria
+
+### Verification Commands
+
+```bash
+# Type check
+bun run typecheck
+
+# Lint
+bun run lint
+
+# Tests
+bun test
+
+# Build
+bun run build
+
+# DB migration
+bun run db:push
+```
+
+### Final Checklist
+
+- [ ] All "Must Have" present
+- [ ] All "Must NOT Have" absent
+- [ ] All tests pass
+- [ ] Calendar renders April 9-10, 2026
+- [ ] CSV exports correctly
+- [ ] Role enforcement works (Chair + Board only)

--- a/src/app/(mobile)/profile/profile-page.stories.tsx
+++ b/src/app/(mobile)/profile/profile-page.stories.tsx
@@ -31,6 +31,7 @@ type Story = StoryObj<typeof meta>;
 const mockUser = {
   name: "Max Mustermann",
   image: "https://i.pravatar.cc/96?u=profile",
+  isHeadOf: false,
 };
 
 const mockProfile = {

--- a/src/app/(mobile)/shifts/page.tsx
+++ b/src/app/(mobile)/shifts/page.tsx
@@ -1,6 +1,9 @@
 import { ShiftManager } from "@/components/shifts/shift-manager";
 import { auth } from "@/lib/auth";
 import { buildLoginRedirect } from "@/lib/utils";
+import { db } from "@/server/db";
+import { memberProfile, user } from "@/server/db/schema";
+import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -10,6 +13,21 @@ export default async function ShiftsPage() {
 
   if (!session?.user?.id) {
     redirect(buildLoginRedirect("/shifts"));
+  }
+
+  const userId = session.user.id;
+  const [profile, userRow] = await Promise.all([
+    db.query.memberProfile.findFirst({
+      where: eq(memberProfile.userId, userId),
+    }),
+    db.select({ isHeadOf: user.isHeadOf }).from(user).where(eq(user.id, userId)).limit(1),
+  ]);
+
+  const isHeadOf = userRow[0]?.isHeadOf ?? false;
+  const isPlanner = profile?.division === "chair" || isHeadOf;
+
+  if (!isPlanner) {
+    redirect("/dashboard");
   }
 
   return (

--- a/src/app/(mobile)/shifts/page.tsx
+++ b/src/app/(mobile)/shifts/page.tsx
@@ -1,3 +1,4 @@
+import { ShiftManager } from "@/components/shifts/shift-manager";
 import { auth } from "@/lib/auth";
 import { buildLoginRedirect } from "@/lib/utils";
 import { headers } from "next/headers";
@@ -13,9 +14,7 @@ export default async function ShiftsPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-8">
-      <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
-      <p className="mt-2 text-muted-foreground">Your upcoming shifts will appear here.</p>
-      {/* TODO: Shifts list */}
+      <ShiftManager />
     </div>
   );
 }

--- a/src/app/(mobile)/shifts/shifts-page.stories.tsx
+++ b/src/app/(mobile)/shifts/shifts-page.stories.tsx
@@ -272,6 +272,14 @@ export const ListViewLoading: Story = {
             profile: mockRegularProfile,
           };
         }),
+        trpcQuery("shift", "list", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return {
+            items: [],
+            total: 0,
+            nextCursor: null,
+          };
+        }),
       ],
     },
   },
@@ -307,9 +315,24 @@ export const CalendarView: Story = {
           profile: mockRegularProfile,
         })),
         trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
         trpcQuery("shift", "calendar", () => mockCalendarSlots),
       ],
     },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the Calendar view button to switch to calendar mode
+    const calendarButton = canvasElement.querySelector('button[aria-label="Calendar view"]');
+    if (calendarButton) {
+      (calendarButton as HTMLButtonElement).click();
+    }
   },
 };
 
@@ -325,9 +348,24 @@ export const CalendarViewPlanner: Story = {
           profile: mockPlannerProfile,
         })),
         trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
         trpcQuery("shift", "calendar", () => mockCalendarSlots),
       ],
     },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the Calendar view button to switch to calendar mode
+    const calendarButton = canvasElement.querySelector('button[aria-label="Calendar view"]');
+    if (calendarButton) {
+      (calendarButton as HTMLButtonElement).click();
+    }
   },
 };
 
@@ -343,8 +381,23 @@ export const CalendarViewEmpty: Story = {
           profile: mockRegularProfile,
         })),
         trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: [],
+          total: 0,
+          nextCursor: null,
+        })),
         trpcQuery("shift", "calendar", () => []),
       ],
     },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the Calendar view button to switch to calendar mode
+    const calendarButton = canvasElement.querySelector('button[aria-label="Calendar view"]');
+    if (calendarButton) {
+      (calendarButton as HTMLButtonElement).click();
+    }
   },
 };

--- a/src/app/(mobile)/shifts/shifts-page.stories.tsx
+++ b/src/app/(mobile)/shifts/shifts-page.stories.tsx
@@ -123,6 +123,7 @@ const mockUser = {
   id: "user-1",
   name: "Max Mustermann",
   email: "max@example.com",
+  isHeadOf: false,
   image: "https://i.pravatar.cc/150?u=shift-manager",
 };
 

--- a/src/components/profile/profile-form.stories.tsx
+++ b/src/components/profile/profile-form.stories.tsx
@@ -27,6 +27,7 @@ type Story = StoryObj<typeof meta>;
 const mockUser = {
   name: "Max Mustermann",
   image: "https://i.pravatar.cc/96?u=max",
+  isHeadOf: false,
 };
 
 const mockProfile = {

--- a/src/components/shifts/calendar-view.stories.tsx
+++ b/src/components/shifts/calendar-view.stories.tsx
@@ -827,7 +827,7 @@ export const Interactive: Story = {
     const cells = canvasElement.querySelectorAll('[class*="cursor-pointer"]');
     const shiftCells = Array.from(cells).filter((cell) => {
       const className = cell.className || "";
-      return className.includes("bg-primary") || className.includes("bg-");
+      return className.includes("bg-primary");
     });
     if (shiftCells.length > 0) {
       (shiftCells[0] as HTMLElement).click();

--- a/src/components/shifts/calendar-view.stories.tsx
+++ b/src/components/shifts/calendar-view.stories.tsx
@@ -1,0 +1,830 @@
+/**
+ * Stories for the CalendarView component.
+ *
+ * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
+ * Demonstrates loading state, empty state, populated state with different headcounts,
+ * and day navigation.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { trpcQuery } from "../../../.storybook/utils/trpc-helpers";
+import { CalendarView } from "./calendar-view";
+
+const meta = {
+  title: "Shifts/CalendarView",
+  component: CalendarView,
+  parameters: {
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof CalendarView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Mock Data
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const april9Date = new Date(2026, 3, 9);
+const april10Date = new Date(2026, 3, 10);
+
+/** Helper to create a slot time on April 9 */
+function slotTime(hour: number, minute: number): Date {
+  const date = new Date(april9Date);
+  date.setHours(hour, minute, 0, 0);
+  return date;
+}
+
+/** Helper to create a slot time on April 10 */
+function slotTimeApril10(hour: number, minute: number): Date {
+  const date = new Date(april10Date);
+  date.setHours(hour, minute, 0, 0);
+  return date;
+}
+
+const _mockLocations = [
+  "Munich Central Station",
+  "Conference Hall A",
+  "Catering Area",
+  "Parking Lot",
+];
+
+const mockCalendarSlotsApril9 = [
+  // Morning slots
+  {
+    slotTime: slotTime(6, 0),
+    totalHeadcount: 2,
+    shifts: [
+      {
+        shiftId: "shift-1",
+        location: "Conference Hall A",
+        task: "Stage Setup",
+        description: "Assist with audio/visual equipment setup",
+        notionLink: null,
+        startTime: slotTime(6, 0),
+        endTime: slotTime(9, 0),
+        headcount: 2,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(6, 30),
+    totalHeadcount: 2,
+    shifts: [
+      {
+        shiftId: "shift-1",
+        location: "Conference Hall A",
+        task: "Stage Setup",
+        description: "Assist with audio/visual equipment setup",
+        notionLink: null,
+        startTime: slotTime(6, 0),
+        endTime: slotTime(9, 0),
+        headcount: 2,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(8, 0),
+    totalHeadcount: 4,
+    shifts: [
+      {
+        shiftId: "shift-2",
+        location: "Munich Central Station",
+        task: "Registration Desk",
+        description: "Handle participant check-ins and distribute badges",
+        notionLink: "https://notion.so/shift-2",
+        startTime: slotTime(8, 0),
+        endTime: slotTime(12, 0),
+        headcount: 4,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(8, 30),
+    totalHeadcount: 4,
+    shifts: [
+      {
+        shiftId: "shift-2",
+        location: "Munich Central Station",
+        task: "Registration Desk",
+        description: "Handle participant check-ins and distribute badges",
+        notionLink: "https://notion.so/shift-2",
+        startTime: slotTime(8, 0),
+        endTime: slotTime(12, 0),
+        headcount: 4,
+      },
+    ],
+  },
+  // Midday slots
+  {
+    slotTime: slotTime(12, 0),
+    totalHeadcount: 10,
+    shifts: [
+      {
+        shiftId: "shift-3",
+        location: "Catering Area",
+        task: "Food Service",
+        description: "Serve meals and manage dietary requirements",
+        notionLink: "https://notion.so/shift-3",
+        startTime: slotTime(12, 0),
+        endTime: slotTime(15, 0),
+        headcount: 6,
+      },
+      {
+        shiftId: "shift-4",
+        location: "Munich Central Station",
+        task: "Registration Desk",
+        description: "Handle participant check-ins and distribute badges",
+        notionLink: "https://notion.so/shift-2",
+        startTime: slotTime(8, 0),
+        endTime: slotTime(12, 0),
+        headcount: 4,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(12, 30),
+    totalHeadcount: 6,
+    shifts: [
+      {
+        shiftId: "shift-3",
+        location: "Catering Area",
+        task: "Food Service",
+        description: "Serve meals and manage dietary requirements",
+        notionLink: "https://notion.so/shift-3",
+        startTime: slotTime(12, 0),
+        endTime: slotTime(15, 0),
+        headcount: 6,
+      },
+    ],
+  },
+  // Afternoon slots
+  {
+    slotTime: slotTime(14, 0),
+    totalHeadcount: 8,
+    shifts: [
+      {
+        shiftId: "shift-5",
+        location: "Conference Hall A",
+        task: "Session Support",
+        description: "Assist speakers and manage Q&A sessions",
+        notionLink: null,
+        startTime: slotTime(14, 0),
+        endTime: slotTime(18, 0),
+        headcount: 3,
+      },
+      {
+        shiftId: "shift-3",
+        location: "Catering Area",
+        task: "Food Service",
+        description: "Serve meals and manage dietary requirements",
+        notionLink: "https://notion.so/shift-3",
+        startTime: slotTime(12, 0),
+        endTime: slotTime(15, 0),
+        headcount: 6,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(14, 30),
+    totalHeadcount: 9,
+    shifts: [
+      {
+        shiftId: "shift-5",
+        location: "Conference Hall A",
+        task: "Session Support",
+        description: "Assist speakers and manage Q&A sessions",
+        notionLink: null,
+        startTime: slotTime(14, 0),
+        endTime: slotTime(18, 0),
+        headcount: 3,
+      },
+      {
+        shiftId: "shift-3",
+        location: "Catering Area",
+        task: "Food Service",
+        description: "Serve meals and manage dietary requirements",
+        notionLink: "https://notion.so/shift-3",
+        startTime: slotTime(12, 0),
+        endTime: slotTime(15, 0),
+        headcount: 6,
+      },
+    ],
+  },
+  // Evening slots
+  {
+    slotTime: slotTime(18, 0),
+    totalHeadcount: 5,
+    shifts: [
+      {
+        shiftId: "shift-6",
+        location: "Parking Lot",
+        task: "Traffic Direction",
+        description: "Guide vehicles and manage parking flow",
+        notionLink: null,
+        startTime: slotTime(18, 0),
+        endTime: slotTime(22, 0),
+        headcount: 5,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(18, 30),
+    totalHeadcount: 5,
+    shifts: [
+      {
+        shiftId: "shift-6",
+        location: "Parking Lot",
+        task: "Traffic Direction",
+        description: "Guide vehicles and manage parking flow",
+        notionLink: null,
+        startTime: slotTime(18, 0),
+        endTime: slotTime(22, 0),
+        headcount: 5,
+      },
+    ],
+  },
+  {
+    slotTime: slotTime(22, 0),
+    totalHeadcount: 3,
+    shifts: [
+      {
+        shiftId: "shift-7",
+        location: "Conference Hall A",
+        task: "Cleanup",
+        description: "Post-event cleanup and equipment storage",
+        notionLink: null,
+        startTime: slotTime(22, 0),
+        endTime: slotTime(23, 0),
+        headcount: 3,
+      },
+    ],
+  },
+];
+
+const mockCalendarSlotsApril10 = [
+  {
+    slotTime: slotTimeApril10(7, 0),
+    totalHeadcount: 3,
+    shifts: [
+      {
+        shiftId: "shift-8",
+        location: "Parking Lot",
+        task: "Traffic Direction",
+        description: "Guide vehicles and manage parking flow",
+        notionLink: null,
+        startTime: slotTimeApril10(7, 0),
+        endTime: slotTimeApril10(19, 0),
+        headcount: 3,
+      },
+    ],
+  },
+  {
+    slotTime: slotTimeApril10(7, 30),
+    totalHeadcount: 3,
+    shifts: [
+      {
+        shiftId: "shift-8",
+        location: "Parking Lot",
+        task: "Traffic Direction",
+        description: "Guide vehicles and manage parking flow",
+        notionLink: null,
+        startTime: slotTimeApril10(7, 0),
+        endTime: slotTimeApril10(19, 0),
+        headcount: 3,
+      },
+    ],
+  },
+];
+
+const mockUser = {
+  id: "user-1",
+  name: "Max Mustermann",
+  email: "max@example.com",
+  image: "https://i.pravatar.cc/150?u=calendar-view",
+};
+
+function createCalendarHandlers(
+  options: {
+    division?: "chair" | "tech";
+    calendarSlots?: unknown[];
+  } = {},
+) {
+  const { division = "chair", calendarSlots = [] } = options;
+
+  return [
+    trpcQuery("profile", "getMy", () => ({
+      user: mockUser,
+      profile: {
+        id: "profile-1",
+        userId: "user-1",
+        status: "active" as const,
+        division,
+        team: "board",
+        lastActiveYear: 2025,
+        teamOther: null,
+        phoneNumber: null,
+        privateEmail: null,
+        linkedInUrl: null,
+        talentIds: [],
+      },
+    })),
+    trpcQuery("shift", "list", () => ({
+      items: [],
+      total: 0,
+      nextCursor: null,
+    })),
+    trpcQuery("shift", "calendar", () => calendarSlots),
+  ];
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Stories
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Loading state - shows skeleton placeholders while data is being fetched.
+ */
+export const Loading: Story = {
+  args: {
+    slots: [],
+    selectedDate: april9Date,
+    isLoading: true,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers(),
+    },
+  },
+};
+
+/**
+ * Empty state - no shifts scheduled for the selected day.
+ */
+export const Empty: Story = {
+  args: {
+    slots: [],
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({ calendarSlots: [] }),
+    },
+  },
+};
+
+/**
+ * Populated state - multiple shifts across different locations and times.
+ * Shows the full calendar grid with headcounts.
+ */
+export const Populated: Story = {
+  args: {
+    slots: mockCalendarSlotsApril9,
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({ calendarSlots: mockCalendarSlotsApril9 }),
+    },
+  },
+};
+
+/**
+ * April 10 view - shows shifts for the second day of Q-Summit.
+ */
+export const April10: Story = {
+  args: {
+    slots: mockCalendarSlotsApril10,
+    selectedDate: april10Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({ calendarSlots: mockCalendarSlotsApril10 }),
+    },
+  },
+};
+
+/**
+ * Single location - only one location has shifts scheduled.
+ */
+export const SingleLocation: Story = {
+  args: {
+    slots: [
+      {
+        slotTime: slotTime(9, 0),
+        totalHeadcount: 2,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Conference Hall A",
+            task: "Registration",
+            description: "Handle participant check-ins",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(12, 0),
+            headcount: 2,
+          },
+        ],
+      },
+      {
+        slotTime: slotTime(9, 30),
+        totalHeadcount: 2,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Conference Hall A",
+            task: "Registration",
+            description: "Handle participant check-ins",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(12, 0),
+            headcount: 2,
+          },
+        ],
+      },
+    ],
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({
+        calendarSlots: [
+          {
+            slotTime: slotTime(9, 0),
+            totalHeadcount: 2,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Conference Hall A",
+                task: "Registration",
+                description: "Handle participant check-ins",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(12, 0),
+                headcount: 2,
+              },
+            ],
+          },
+          {
+            slotTime: slotTime(9, 30),
+            totalHeadcount: 2,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Conference Hall A",
+                task: "Registration",
+                description: "Handle participant check-ins",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(12, 0),
+                headcount: 2,
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  },
+};
+
+/**
+ * High headcount - demonstrates cells with large volunteer numbers.
+ */
+export const HighHeadcount: Story = {
+  args: {
+    slots: [
+      {
+        slotTime: slotTime(12, 0),
+        totalHeadcount: 25,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Catering Area",
+            task: "Lunch Service",
+            description: "Serve lunch to all attendees",
+            notionLink: null,
+            startTime: slotTime(12, 0),
+            endTime: slotTime(14, 0),
+            headcount: 15,
+          },
+          {
+            shiftId: "shift-2",
+            location: "Conference Hall A",
+            task: "Session Support",
+            description: "Assist with main session",
+            notionLink: null,
+            startTime: slotTime(12, 0),
+            endTime: slotTime(14, 0),
+            headcount: 10,
+          },
+        ],
+      },
+      {
+        slotTime: slotTime(12, 30),
+        totalHeadcount: 25,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Catering Area",
+            task: "Lunch Service",
+            description: "Serve lunch to all attendees",
+            notionLink: null,
+            startTime: slotTime(12, 0),
+            endTime: slotTime(14, 0),
+            headcount: 15,
+          },
+          {
+            shiftId: "shift-2",
+            location: "Conference Hall A",
+            task: "Session Support",
+            description: "Assist with main session",
+            notionLink: null,
+            startTime: slotTime(12, 0),
+            endTime: slotTime(14, 0),
+            headcount: 10,
+          },
+        ],
+      },
+    ],
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({
+        calendarSlots: [
+          {
+            slotTime: slotTime(12, 0),
+            totalHeadcount: 25,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Catering Area",
+                task: "Lunch Service",
+                description: "Serve lunch to all attendees",
+                notionLink: null,
+                startTime: slotTime(12, 0),
+                endTime: slotTime(14, 0),
+                headcount: 15,
+              },
+              {
+                shiftId: "shift-2",
+                location: "Conference Hall A",
+                task: "Session Support",
+                description: "Assist with main session",
+                notionLink: null,
+                startTime: slotTime(12, 0),
+                endTime: slotTime(14, 0),
+                headcount: 10,
+              },
+            ],
+          },
+          {
+            slotTime: slotTime(12, 30),
+            totalHeadcount: 25,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Catering Area",
+                task: "Lunch Service",
+                description: "Serve lunch to all attendees",
+                notionLink: null,
+                startTime: slotTime(12, 0),
+                endTime: slotTime(14, 0),
+                headcount: 15,
+              },
+              {
+                shiftId: "shift-2",
+                location: "Conference Hall A",
+                task: "Session Support",
+                description: "Assist with main session",
+                notionLink: null,
+                startTime: slotTime(12, 0),
+                endTime: slotTime(14, 0),
+                headcount: 10,
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  },
+};
+
+/**
+ * Zero headcount - shows shifts with no volunteers assigned.
+ */
+export const ZeroHeadcount: Story = {
+  args: {
+    slots: [
+      {
+        slotTime: slotTime(10, 0),
+        totalHeadcount: 0,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Munich Central Station",
+            task: "Info Desk",
+            description: "Information desk for attendees",
+            notionLink: null,
+            startTime: slotTime(10, 0),
+            endTime: slotTime(12, 0),
+            headcount: 0,
+          },
+        ],
+      },
+    ],
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({
+        calendarSlots: [
+          {
+            slotTime: slotTime(10, 0),
+            totalHeadcount: 0,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Munich Central Station",
+                task: "Info Desk",
+                description: "Information desk for attendees",
+                notionLink: null,
+                startTime: slotTime(10, 0),
+                endTime: slotTime(12, 0),
+                headcount: 0,
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  },
+};
+
+/**
+ * Many locations - demonstrates the grid with many different locations.
+ */
+export const ManyLocations: Story = {
+  args: {
+    slots: [
+      {
+        slotTime: slotTime(9, 0),
+        totalHeadcount: 12,
+        shifts: [
+          {
+            shiftId: "shift-1",
+            location: "Main Entrance",
+            task: "Registration",
+            description: "Handle check-ins",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(12, 0),
+            headcount: 3,
+          },
+          {
+            shiftId: "shift-2",
+            location: "Hall A",
+            task: "Setup",
+            description: "Setup equipment",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(11, 0),
+            headcount: 2,
+          },
+          {
+            shiftId: "shift-3",
+            location: "Hall B",
+            task: "Setup",
+            description: "Setup equipment",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(11, 0),
+            headcount: 2,
+          },
+          {
+            shiftId: "shift-4",
+            location: "Catering",
+            task: "Prep",
+            description: "Food preparation",
+            notionLink: null,
+            startTime: slotTime(9, 0),
+            endTime: slotTime(14, 0),
+            headcount: 5,
+          },
+        ],
+      },
+    ],
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({
+        calendarSlots: [
+          {
+            slotTime: slotTime(9, 0),
+            totalHeadcount: 12,
+            shifts: [
+              {
+                shiftId: "shift-1",
+                location: "Main Entrance",
+                task: "Registration",
+                description: "Handle check-ins",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(12, 0),
+                headcount: 3,
+              },
+              {
+                shiftId: "shift-2",
+                location: "Hall A",
+                task: "Setup",
+                description: "Setup equipment",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(11, 0),
+                headcount: 2,
+              },
+              {
+                shiftId: "shift-3",
+                location: "Hall B",
+                task: "Setup",
+                description: "Setup equipment",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(11, 0),
+                headcount: 2,
+              },
+              {
+                shiftId: "shift-4",
+                location: "Catering",
+                task: "Prep",
+                description: "Food preparation",
+                notionLink: null,
+                startTime: slotTime(9, 0),
+                endTime: slotTime(14, 0),
+                headcount: 5,
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  },
+};
+
+/**
+ * Non-planner view - shows the calendar from a regular volunteer's perspective.
+ */
+export const NonPlanner: Story = {
+  args: {
+    slots: mockCalendarSlotsApril9,
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({
+        division: "tech",
+        calendarSlots: mockCalendarSlotsApril9,
+      }),
+    },
+  },
+};
+
+/**
+ * Interactive story - demonstrates clicking on cells to view shift details.
+ * Click on any cell with a headcount badge to open the details modal.
+ */
+export const Interactive: Story = {
+  args: {
+    slots: mockCalendarSlotsApril9,
+    selectedDate: april9Date,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: createCalendarHandlers({ calendarSlots: mockCalendarSlotsApril9 }),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Find and click a cell with headcount (Catering Area at 12:00)
+    const cells = canvasElement.querySelectorAll('[class*="cursor-pointer"][class*="bg-primary"]');
+    if (cells.length > 0) {
+      (cells[0] as HTMLElement).click();
+    }
+  },
+};

--- a/src/components/shifts/calendar-view.stories.tsx
+++ b/src/components/shifts/calendar-view.stories.tsx
@@ -822,9 +822,14 @@ export const Interactive: Story = {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Find and click a cell with headcount (Catering Area at 12:00)
-    const cells = canvasElement.querySelectorAll('[class*="cursor-pointer"][class*="bg-primary"]');
-    if (cells.length > 0) {
-      (cells[0] as HTMLElement).click();
+    // Note: bg-primary/5 is the actual class used for cells with shifts
+    const cells = canvasElement.querySelectorAll('[class*="cursor-pointer"]');
+    const shiftCells = Array.from(cells).filter((cell) => {
+      const className = cell.className || "";
+      return className.includes("bg-primary") || className.includes("bg-");
+    });
+    if (shiftCells.length > 0) {
+      (shiftCells[0] as HTMLElement).click();
     }
   },
 };

--- a/src/components/shifts/calendar-view.stories.tsx
+++ b/src/components/shifts/calendar-view.stories.tsx
@@ -306,6 +306,7 @@ const mockUser = {
   name: "Max Mustermann",
   email: "max@example.com",
   image: "https://i.pravatar.cc/150?u=calendar-view",
+  isHeadOf: false,
 };
 
 function createCalendarHandlers(

--- a/src/components/shifts/calendar-view.tsx
+++ b/src/components/shifts/calendar-view.tsx
@@ -220,7 +220,7 @@ function ShiftDetailModal({ slot, isOpen, onClose }: ShiftDetailModalProps) {
             size="icon"
             onClick={onClose}
             className="h-9 w-9"
-            aria-label="Close modal"
+            aria-label="Close"
           >
             <X className="h-5 w-5" />
           </Button>
@@ -474,8 +474,16 @@ export function CalendarView({
                           <button
                             key={`${slotTime.getTime()}-${location}`}
                             type="button"
+                            role="button"
+                            tabIndex={0}
                             className="w-full cursor-pointer border-b border-r border-border bg-primary/5 p-2 hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                             onClick={() => handleCellClick(slotTime, location)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                handleCellClick(slotTime, location);
+                              }
+                            }}
                             aria-label={`${location}, ${formatTime(slotTime)}, ${headcount} volunteer${headcount !== 1 ? "s" : ""}, view details`}
                           >
                             <div className="flex items-center justify-center">

--- a/src/components/shifts/calendar-view.tsx
+++ b/src/components/shifts/calendar-view.tsx
@@ -214,7 +214,13 @@ function ShiftDetailModal({ slot, isOpen, onClose }: ShiftDetailModalProps) {
               {slot.totalHeadcount !== 1 ? "s" : ""}
             </p>
           </div>
-          <Button variant="ghost" size="icon" onClick={onClose} className="h-9 w-9">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="h-9 w-9"
+            aria-label="Close modal"
+          >
             <X className="h-5 w-5" />
           </Button>
         </div>

--- a/src/components/shifts/calendar-view.tsx
+++ b/src/components/shifts/calendar-view.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { api } from "@/server/api/client";
+import { useIsPlanner } from "@/lib/use-is-planner";
+import { ChevronLeft, ChevronRight, Clock, MapPin, Users, Calendar, X } from "lucide-react";
+import * as React from "react";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Constants
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Q-Summit 2026 dates */
+const QSUMMIT_DATES = [
+  new Date(2026, 3, 9), // April 9, 2026 (month is 0-indexed)
+  new Date(2026, 3, 10), // April 10, 2026
+];
+
+/** Calendar time range: 06:00 to 23:00 */
+const START_HOUR = 6;
+const END_HOUR = 23;
+const _SLOT_DURATION_MINUTES = 30;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Types
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface CalendarSlot {
+  slotTime: Date;
+  totalHeadcount: number;
+  shifts: {
+    shiftId: string;
+    location: string;
+    task: string;
+    description: string | null;
+    notionLink: string | null;
+    startTime: Date;
+    endTime: Date;
+    headcount: number;
+  }[];
+}
+
+interface CalendarViewProps {
+  /** Pre-loaded slots data (optional - for Storybook) */
+  slots?: CalendarSlot[];
+  /** Currently selected date */
+  selectedDate?: Date;
+  /** Callback when date changes */
+  onDateChange?: (date: Date) => void;
+  /** Loading state (for Storybook) */
+  isLoading?: boolean;
+}
+
+interface ShiftDetailModalProps {
+  slot: CalendarSlot | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Helper Functions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function formatTime(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  }).format(date);
+}
+
+function _formatDateShort(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function formatDateTimeRange(start: Date, end: Date): string {
+  return `${formatTime(start)} - ${formatTime(end)}`;
+}
+
+/** Generate all 30-min time slots from START_HOUR to END_HOUR */
+function generateTimeSlots(): Date[] {
+  const slots: Date[] = [];
+  const baseDate = new Date(2026, 3, 9); // Use April 9 as base
+
+  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
+    for (const minute of [0, 30]) {
+      if (hour === END_HOUR && minute === 30) break;
+      const slotTime = new Date(baseDate);
+      slotTime.setHours(hour, minute, 0, 0);
+      slots.push(slotTime);
+    }
+  }
+
+  return slots;
+}
+
+/** Get unique locations from all slots */
+function getUniqueLocations(slots: CalendarSlot[]): string[] {
+  const locations = new Set<string>();
+  for (const slot of slots) {
+    for (const shift of slot.shifts) {
+      locations.add(shift.location);
+    }
+  }
+  return Array.from(locations).sort();
+}
+
+/** Get headcount for a specific slot time and location */
+function getHeadcountForSlot(slots: CalendarSlot[], slotTime: Date, location: string): number {
+  const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
+  if (!slot) return 0;
+
+  const shift = slot.shifts.find((sh) => sh.location === location);
+  return shift?.headcount ?? 0;
+}
+
+/** Get shifts for a specific slot time and location */
+function getShiftsForSlot(
+  slots: CalendarSlot[],
+  slotTime: Date,
+  location: string,
+): CalendarSlot["shifts"] {
+  const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
+  if (!slot) return [];
+
+  return slot.shifts.filter((sh) => sh.location === location);
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sub-Components
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function LoadingState() {
+  const timeSlots = generateTimeSlots();
+
+  return (
+    <div className="grid gap-4">
+      {/* Header Skeleton */}
+      <div className="flex items-center justify-between rounded-xl border border-border bg-white p-3 shadow-sm">
+        <div className="h-9 w-9 animate-pulse rounded bg-muted" />
+        <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-9 w-9 animate-pulse rounded bg-muted" />
+      </div>
+
+      {/* Calendar Grid Skeleton */}
+      <Card className="overflow-hidden border-border">
+        <div className="grid" style={{ gridTemplateColumns: `80px repeat(3, 1fr)` }}>
+          {/* Time column header */}
+          <div className="border-b border-r border-border bg-muted/50 p-3">
+            <div className="h-4 w-12 animate-pulse rounded bg-muted" />
+          </div>
+          {/* Location headers */}
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="border-b border-r border-border bg-muted/50 p-3">
+              <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+
+          {/* Time slots */}
+          {timeSlots.map((_, index) => (
+            <React.Fragment key={index}>
+              <div className="border-b border-r border-border p-3">
+                <div className="h-4 w-12 animate-pulse rounded bg-muted" />
+              </div>
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="border-b border-r border-border p-3">
+                  <div className="mx-auto h-6 w-8 animate-pulse rounded bg-muted" />
+                </div>
+              ))}
+            </React.Fragment>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function EmptyState({ message = "No shifts scheduled" }: { message?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-muted/30 py-12 text-center">
+      <Calendar className="mb-3 h-10 w-10 text-muted-foreground/50" />
+      <p className="text-sm font-medium text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+function ShiftDetailModal({ slot, isOpen, onClose }: ShiftDetailModalProps) {
+  if (!isOpen || !slot) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl bg-background p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-foreground">
+              {formatTime(slot.slotTime)} Shifts
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {slot.shifts.length} shift{slot.shifts.length !== 1 ? "s" : ""} •{" "}
+              {slot.totalHeadcount} volunteer
+              {slot.totalHeadcount !== 1 ? "s" : ""}
+            </p>
+          </div>
+          <Button variant="ghost" size="icon" onClick={onClose} className="h-9 w-9">
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <div className="grid gap-3">
+          {slot.shifts.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No shifts at this time</p>
+          ) : (
+            slot.shifts.map((shift) => (
+              <Card key={shift.shiftId} className="overflow-hidden border-border bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate font-semibold text-foreground">{shift.task}</h3>
+                    <div className="mt-1 flex flex-col gap-1 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-1.5">
+                        <MapPin className="h-3.5 w-3.5" />
+                        <span className="truncate">{shift.location}</span>
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <Clock className="h-3.5 w-3.5" />
+                        <span>{formatDateTimeRange(shift.startTime, shift.endTime)}</span>
+                      </div>
+                    </div>
+                    {shift.description && (
+                      <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">
+                        {shift.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                    <Users className="h-3.5 w-3.5" />
+                    <span>{shift.headcount}</span>
+                  </div>
+                </div>
+              </Card>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function CalendarView({
+  slots: propSlots,
+  selectedDate: propSelectedDate,
+  onDateChange: propOnDateChange,
+  isLoading: propIsLoading,
+}: CalendarViewProps) {
+  const { isPlanner: _isPlanner } = useIsPlanner();
+
+  // Internal state for date (used when props not provided)
+  const [internalDate, setInternalDate] = React.useState(() => QSUMMIT_DATES[0]);
+  const [selectedSlot, setSelectedSlot] = React.useState<CalendarSlot | null>(null);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
+  // Use prop value or internal state
+  const selectedDate = propSelectedDate ?? internalDate;
+  const setSelectedDate = propOnDateChange ?? setInternalDate;
+
+  // Fetch calendar data from tRPC (only if slots not provided via props)
+  const {
+    data: fetchedSlots,
+    isLoading: isFetching,
+    error,
+  } = api.shift.calendar.useQuery(
+    { date: selectedDate },
+    {
+      refetchOnWindowFocus: false,
+      enabled: propSlots === undefined,
+    },
+  );
+
+  // Memoize slots to prevent dependency changes on every render
+  const slots = React.useMemo(
+    () => propSlots ?? (fetchedSlots as CalendarSlot[]) ?? [],
+    [propSlots, fetchedSlots],
+  );
+  const isLoading = propIsLoading ?? isFetching;
+
+  // Generate time slots
+  const timeSlots = React.useMemo(() => generateTimeSlots(), []);
+
+  // Get unique locations
+  const locations = React.useMemo(() => getUniqueLocations(slots), [slots]);
+
+  // Navigation handlers
+  const navigateDay = (direction: "prev" | "next") => {
+    const currentIndex = QSUMMIT_DATES.findIndex((d) => d.getTime() === selectedDate.getTime());
+    const newIndex =
+      direction === "next"
+        ? Math.min(currentIndex + 1, QSUMMIT_DATES.length - 1)
+        : Math.max(currentIndex - 1, 0);
+    setSelectedDate(QSUMMIT_DATES[newIndex]);
+  };
+
+  const canGoPrev = QSUMMIT_DATES.findIndex((d) => d.getTime() === selectedDate.getTime()) > 0;
+  const canGoNext =
+    QSUMMIT_DATES.findIndex((d) => d.getTime() === selectedDate.getTime()) <
+    QSUMMIT_DATES.length - 1;
+
+  // Handle cell click
+  const handleCellClick = (slotTime: Date, location: string) => {
+    const slotShifts = getShiftsForSlot(slots, slotTime, location);
+    const totalHeadcount = slotShifts.reduce((sum, s) => sum + s.headcount, 0);
+
+    if (slotShifts.length > 0) {
+      setSelectedSlot({
+        slotTime,
+        totalHeadcount,
+        shifts: slotShifts,
+      });
+      setIsModalOpen(true);
+    }
+  };
+
+  // Handle time row click (show all shifts for that time)
+  const handleTimeRowClick = (slotTime: Date) => {
+    const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
+    if (slot && slot.shifts.length > 0) {
+      setSelectedSlot(slot);
+      setIsModalOpen(true);
+    }
+  };
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+        <p className="text-sm font-medium">Failed to load calendar data</p>
+        <p className="text-xs">{error.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      {/* Date Navigation */}
+      <div className="flex items-center justify-between rounded-xl border border-border bg-white p-3 shadow-sm">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigateDay("prev")}
+          disabled={!canGoPrev}
+          className="h-9 w-9"
+          aria-label="Previous day"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <div className="text-center">
+          <div className="font-semibold text-foreground">{formatDate(selectedDate)}</div>
+          <div className="text-xs text-muted-foreground">Q-Summit 2026</div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigateDay("next")}
+          disabled={!canGoNext}
+          className="h-9 w-9"
+          aria-label="Next day"
+        >
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      </div>
+
+      {/* Calendar Grid */}
+      {slots.length === 0 ? (
+        <EmptyState message="No shifts scheduled for this day" />
+      ) : (
+        <Card className="overflow-hidden border-border">
+          <div className="overflow-x-auto" role="region" aria-label="Calendar grid" tabIndex={0}>
+            <div
+              className="grid min-w-[600px]"
+              style={{
+                gridTemplateColumns: `80px repeat(${Math.max(locations.length, 1)}, 1fr)`,
+              }}
+            >
+              {/* Header Row */}
+              <div className="sticky left-0 z-10 border-b border-r border-border bg-muted/50 p-3">
+                <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
+                  <Clock className="h-3.5 w-3.5" />
+                  <span>Time</span>
+                </div>
+              </div>
+              {locations.length === 0 ? (
+                <div className="border-b border-r border-border bg-muted/50 p-3">
+                  <span className="text-xs font-semibold text-muted-foreground">Location</span>
+                </div>
+              ) : (
+                locations.map((location) => (
+                  <div key={location} className="border-b border-r border-border bg-muted/50 p-3">
+                    <div className="flex items-center gap-1.5">
+                      <MapPin className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span
+                        className="truncate text-xs font-semibold text-muted-foreground"
+                        title={location}
+                      >
+                        {location}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+
+              {/* Time Slots */}
+              {timeSlots.map((slotTime) => {
+                const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
+                const hasAnyShifts = slot && slot.shifts.length > 0;
+
+                return (
+                  <React.Fragment key={slotTime.getTime()}>
+                    {/* Time Column */}
+                    <div
+                      className={`sticky left-0 z-10 border-b border-r border-border bg-muted/30 p-3 ${
+                        hasAnyShifts ? "cursor-pointer hover:bg-muted/50" : ""
+                      }`}
+                      onClick={() => handleTimeRowClick(slotTime)}
+                    >
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {formatTime(slotTime)}
+                      </span>
+                    </div>
+
+                    {/* Location Cells */}
+                    {locations.length === 0 ? (
+                      <div className="border-b border-r border-border p-3">
+                        <span className="text-xs text-muted-foreground">-</span>
+                      </div>
+                    ) : (
+                      locations.map((location) => {
+                        const headcount = getHeadcountForSlot(slots, slotTime, location);
+                        const hasShifts = headcount > 0;
+
+                        return (
+                          <div
+                            key={`${slotTime.getTime()}-${location}`}
+                            className={`border-b border-r border-border p-2 ${
+                              hasShifts
+                                ? "cursor-pointer bg-primary/5 hover:bg-primary/10"
+                                : "bg-white"
+                            }`}
+                            onClick={() => handleCellClick(slotTime, location)}
+                          >
+                            <div className="flex items-center justify-center">
+                              {hasShifts ? (
+                                <div className="flex items-center gap-1 rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                                  <Users className="h-3 w-3" />
+                                  <span>{headcount}</span>
+                                </div>
+                              ) : (
+                                <span className="text-xs text-muted-foreground/30">-</span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <div className="h-4 w-4 rounded bg-primary/10" />
+          <span>Has shifts</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="h-4 w-4 rounded border border-border bg-white" />
+          <span>No shifts</span>
+        </div>
+        <div className="ml-auto text-xs">Click a cell to view shift details</div>
+      </div>
+
+      {/* Shift Detail Modal */}
+      <ShiftDetailModal
+        slot={selectedSlot}
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/components/shifts/calendar-view.tsx
+++ b/src/components/shifts/calendar-view.tsx
@@ -90,15 +90,15 @@ function formatDateTimeRange(start: Date, end: Date): string {
   return `${formatTime(start)} - ${formatTime(end)}`;
 }
 
-/** Generate all 30-min time slots from START_HOUR to END_HOUR */
-function generateTimeSlots(): Date[] {
+/** Generate all 30-min time slots from START_HOUR to END_HOUR for the given date */
+function generateTimeSlots(baseDate: Date): Date[] {
   const slots: Date[] = [];
-  const baseDate = new Date(2026, 3, 9); // Use April 9 as base
+  const date = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
 
   for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
     for (const minute of [0, 30]) {
       if (hour === END_HOUR && minute === 30) break;
-      const slotTime = new Date(baseDate);
+      const slotTime = new Date(date);
       slotTime.setHours(hour, minute, 0, 0);
       slots.push(slotTime);
     }
@@ -118,13 +118,14 @@ function getUniqueLocations(slots: CalendarSlot[]): string[] {
   return Array.from(locations).sort();
 }
 
-/** Get headcount for a specific slot time and location */
+/** Get headcount for a specific slot time and location (sums across all matching shifts) */
 function getHeadcountForSlot(slots: CalendarSlot[], slotTime: Date, location: string): number {
   const slot = slots.find((s) => s.slotTime.getTime() === slotTime.getTime());
   if (!slot) return 0;
 
-  const shift = slot.shifts.find((sh) => sh.location === location);
-  return shift?.headcount ?? 0;
+  return slot.shifts
+    .filter((sh) => sh.location === location)
+    .reduce((sum, sh) => sum + sh.headcount, 0);
 }
 
 /** Get shifts for a specific slot time and location */
@@ -144,7 +145,7 @@ function getShiftsForSlot(
  * ────────────────────────────────────────────────────────────────────────── */
 
 function LoadingState() {
-  const timeSlots = generateTimeSlots();
+  const timeSlots = generateTimeSlots(QSUMMIT_DATES[0]);
 
   return (
     <div className="grid gap-4">
@@ -305,8 +306,8 @@ export function CalendarView({
   );
   const isLoading = propIsLoading ?? isFetching;
 
-  // Generate time slots
-  const timeSlots = React.useMemo(() => generateTimeSlots(), []);
+  // Generate time slots for the selected date so slot lookups match API data
+  const timeSlots = React.useMemo(() => generateTimeSlots(selectedDate), [selectedDate]);
 
   // Get unique locations
   const locations = React.useMemo(() => getUniqueLocations(slots), [slots]);
@@ -440,16 +441,24 @@ export function CalendarView({
                 return (
                   <React.Fragment key={slotTime.getTime()}>
                     {/* Time Column */}
-                    <div
-                      className={`sticky left-0 z-10 border-b border-r border-border bg-muted/30 p-3 ${
-                        hasAnyShifts ? "cursor-pointer hover:bg-muted/50" : ""
-                      }`}
-                      onClick={() => handleTimeRowClick(slotTime)}
-                    >
-                      <span className="text-xs font-medium text-muted-foreground">
-                        {formatTime(slotTime)}
-                      </span>
-                    </div>
+                    {hasAnyShifts ? (
+                      <button
+                        type="button"
+                        className="sticky left-0 z-10 w-full cursor-pointer border-b border-r border-border bg-muted/30 p-3 text-left hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                        onClick={() => handleTimeRowClick(slotTime)}
+                        aria-label={`${formatTime(slotTime)}, view shifts`}
+                      >
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {formatTime(slotTime)}
+                        </span>
+                      </button>
+                    ) : (
+                      <div className="sticky left-0 z-10 border-b border-r border-border bg-muted/30 p-3">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {formatTime(slotTime)}
+                        </span>
+                      </div>
+                    )}
 
                     {/* Location Cells */}
                     {locations.length === 0 ? (
@@ -461,25 +470,28 @@ export function CalendarView({
                         const headcount = getHeadcountForSlot(slots, slotTime, location);
                         const hasShifts = headcount > 0;
 
-                        return (
-                          <div
+                        return hasShifts ? (
+                          <button
                             key={`${slotTime.getTime()}-${location}`}
-                            className={`border-b border-r border-border p-2 ${
-                              hasShifts
-                                ? "cursor-pointer bg-primary/5 hover:bg-primary/10"
-                                : "bg-white"
-                            }`}
+                            type="button"
+                            className="w-full cursor-pointer border-b border-r border-border bg-primary/5 p-2 hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                             onClick={() => handleCellClick(slotTime, location)}
+                            aria-label={`${location}, ${formatTime(slotTime)}, ${headcount} volunteer${headcount !== 1 ? "s" : ""}, view details`}
                           >
                             <div className="flex items-center justify-center">
-                              {hasShifts ? (
-                                <div className="flex items-center gap-1 rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-                                  <Users className="h-3 w-3" />
-                                  <span>{headcount}</span>
-                                </div>
-                              ) : (
-                                <span className="text-xs text-muted-foreground/30">-</span>
-                              )}
+                              <div className="flex items-center gap-1 rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                                <Users className="h-3 w-3" />
+                                <span>{headcount}</span>
+                              </div>
+                            </div>
+                          </button>
+                        ) : (
+                          <div
+                            key={`${slotTime.getTime()}-${location}`}
+                            className="border-b border-r border-border bg-white p-2"
+                          >
+                            <div className="flex items-center justify-center">
+                              <span className="text-xs text-muted-foreground/30">-</span>
                             </div>
                           </div>
                         );

--- a/src/components/shifts/csv-export-button.stories.tsx
+++ b/src/components/shifts/csv-export-button.stories.tsx
@@ -109,29 +109,22 @@ export const WithError: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.post("*/api/trpc", async ({ request }) => {
-          const body = (await request.json()) as { json?: { params?: { path?: string } } };
-          const path = body?.json?.params?.path;
-
-          if (path === "shift.exportCsv") {
-            return HttpResponse.json(
-              {
-                id: null,
-                error: {
-                  message: "Failed to export shifts",
-                  code: -32603,
-                  data: {
-                    code: "INTERNAL_SERVER_ERROR",
-                    httpStatus: 500,
-                  },
+        http.post("*/api/trpc/shift.exportCsv", () =>
+          HttpResponse.json(
+            {
+              id: null,
+              error: {
+                message: "Failed to export shifts",
+                code: -32603,
+                data: {
+                  code: "INTERNAL_SERVER_ERROR",
+                  httpStatus: 500,
                 },
               },
-              { status: 500 },
-            );
-          }
-
-          return undefined;
-        }),
+            },
+            { status: 500 },
+          ),
+        ),
       ],
     },
   },

--- a/src/components/shifts/csv-export-button.stories.tsx
+++ b/src/components/shifts/csv-export-button.stories.tsx
@@ -1,0 +1,164 @@
+/**
+ * Stories for the CsvExportButton component.
+ *
+ * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
+ * Demonstrates default, loading, success, and error states.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { http, HttpResponse } from "msw";
+import { trpcMutation } from "../../../.storybook/utils/trpc-helpers";
+import { CsvExportButton } from "./csv-export-button";
+
+const meta = {
+  title: "Shifts/CsvExportButton",
+  component: CsvExportButton,
+  parameters: {
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof CsvExportButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Sample CSV content for mock responses
+const mockCsvContent = `shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
+shift-1;Munich Central Station;Registration Desk;2026-04-09 08:00:00;2026-04-09 12:00:00;2026-04-09 08:00:00;2;driver_18plus;car;https://notion.so/shift-1
+shift-1;Munich Central Station;Registration Desk;2026-04-09 08:00:00;2026-04-09 12:00:00;2026-04-09 08:30:00;2;driver_18plus;car;https://notion.so/shift-1
+shift-2;Conference Hall A;Stage Setup;2026-04-09 06:00:00;2026-04-09 09:00:00;2026-04-09 06:00:00;1;gastro;;`;
+
+/**
+ * Default state - button ready to export.
+ * Click to trigger CSV download.
+ */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcMutation("shift", "exportCsv", () => ({
+          csv: mockCsvContent,
+        })),
+      ],
+    },
+  },
+};
+
+/**
+ * Loading state - export in progress.
+ * Shows spinner while waiting for response.
+ */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcMutation("shift", "exportCsv", async () => {
+          // Simulate slow network
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return { csv: mockCsvContent };
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the export button to trigger loading state
+    const button = canvasElement.querySelector("button");
+    if (button) {
+      button.click();
+    }
+  },
+};
+
+/**
+ * Success state - after successful export.
+ * The button returns to normal state after download.
+ */
+export const WithSuccess: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcMutation("shift", "exportCsv", () => ({
+          csv: mockCsvContent,
+        })),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the export button
+    const button = canvasElement.querySelector("button");
+    if (button) {
+      button.click();
+    }
+  },
+};
+
+/**
+ * Error state - when export fails.
+ * Shows error handling behavior.
+ */
+export const WithError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post("*/api/trpc", async ({ request }) => {
+          const body = (await request.json()) as { json?: { params?: { path?: string } } };
+          const path = body?.json?.params?.path;
+
+          if (path === "shift.exportCsv") {
+            return HttpResponse.json(
+              {
+                id: null,
+                error: {
+                  message: "Failed to export shifts",
+                  code: -32603,
+                  data: {
+                    code: "INTERNAL_SERVER_ERROR",
+                    httpStatus: 500,
+                  },
+                },
+              },
+              { status: 500 },
+            );
+          }
+
+          return undefined;
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Click the export button to trigger error
+    const button = canvasElement.querySelector("button");
+    if (button) {
+      button.click();
+    }
+  },
+};
+
+/**
+ * Empty export - no shifts to export.
+ * Returns CSV with header only.
+ */
+export const EmptyExport: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcMutation("shift", "exportCsv", () => ({
+          csv: "shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link",
+        })),
+      ],
+    },
+  },
+};

--- a/src/components/shifts/csv-export-button.tsx
+++ b/src/components/shifts/csv-export-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { api } from "@/server/api/client";
+import { Download, Loader2 } from "lucide-react";
+import * as React from "react";
+
+interface CsvExportButtonProps {
+  filename?: string;
+}
+
+export function CsvExportButton({ filename = "shifts-export.csv" }: CsvExportButtonProps) {
+  const exportMutation = api.shift.exportCsv.useMutation({
+    onSuccess: (data) => {
+      // Create blob with UTF-8 BOM for German Excel compatibility
+      const bom = "\uFEFF";
+      const blob = new Blob([bom + data.csv], {
+        type: "text/csv;charset=utf-8",
+      });
+
+      // Create download link
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    },
+  });
+
+  const handleExport = () => {
+    exportMutation.mutate();
+  };
+
+  const isPending = exportMutation.isPending;
+
+  return (
+    <Button
+      onClick={handleExport}
+      disabled={isPending}
+      size="sm"
+      variant="outline"
+      className="gap-1.5"
+      aria-label="Export shifts as CSV"
+    >
+      {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+      <span className="hidden sm:inline">Export</span>
+    </Button>
+  );
+}

--- a/src/components/shifts/csv-export-button.tsx
+++ b/src/components/shifts/csv-export-button.tsx
@@ -3,7 +3,6 @@
 import { Button } from "@/components/ui/button";
 import { api } from "@/server/api/client";
 import { Download, Loader2 } from "lucide-react";
-import * as React from "react";
 
 interface CsvExportButtonProps {
   filename?: string;

--- a/src/components/shifts/csv-export-button.tsx
+++ b/src/components/shifts/csv-export-button.tsx
@@ -12,9 +12,8 @@ interface CsvExportButtonProps {
 export function CsvExportButton({ filename = "shifts-export.csv" }: CsvExportButtonProps) {
   const exportMutation = api.shift.exportCsv.useMutation({
     onSuccess: (data) => {
-      // Create blob with UTF-8 BOM for German Excel compatibility
-      const bom = "\uFEFF";
-      const blob = new Blob([bom + data.csv], {
+      // Server already includes UTF-8 BOM for German Excel compatibility
+      const blob = new Blob([data.csv], {
         type: "text/csv;charset=utf-8",
       });
 

--- a/src/components/shifts/shift-form.stories.tsx
+++ b/src/components/shifts/shift-form.stories.tsx
@@ -248,10 +248,13 @@ export const Error: Story = {
       endTimeInputs[1].dispatchEvent(new Event("input", { bubbles: true }));
     }
 
-    // Click submit button
-    const submitButton = canvas.querySelector('button[type="button"]');
-    if (submitButton?.textContent?.includes("Create")) {
-      (submitButton as HTMLButtonElement).click();
+    // Click submit button (look for the button with "Create" text in the modal footer)
+    const buttons = canvasElement.querySelectorAll("button");
+    const submitButton = Array.from(buttons).find(
+      (btn) => btn.textContent?.includes("Create") && !btn.disabled,
+    );
+    if (submitButton) {
+      submitButton.click();
     }
   },
 };

--- a/src/components/shifts/shift-form.stories.tsx
+++ b/src/components/shifts/shift-form.stories.tsx
@@ -1,0 +1,351 @@
+/**
+ * Stories for the ShiftForm component.
+ *
+ * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { http, HttpResponse } from "msw";
+import { trpcMutation, trpcQuery } from "../../../.storybook/utils/trpc-helpers";
+import { ShiftForm } from "./shift-form";
+
+const meta = {
+  title: "Shifts/ShiftForm",
+  component: ShiftForm,
+  parameters: {
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ShiftForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock data for talents query
+const mockTalents = [
+  { id: "talent-1", category: "driver_license", key: "driver_18plus" },
+  { id: "talent-2", category: "driver_license", key: "driver_21plus" },
+  { id: "talent-3", category: "driver_license", key: "driver_c1" },
+  { id: "talent-4", category: "gastronomy", key: "gastro" },
+];
+
+const mockUser = {
+  id: "user-1",
+  name: "Max Mustermann",
+  email: "max@example.com",
+  image: "https://i.pravatar.cc/150?u=shift-form",
+};
+
+const mockPlannerProfile = {
+  id: "profile-1",
+  userId: "user-1",
+  status: "active" as const,
+  division: "chair" as const,
+  team: "board" as const,
+  lastActiveYear: 2025,
+  teamOther: null,
+  phoneNumber: null,
+  privateEmail: null,
+  linkedInUrl: null,
+  talentIds: ["talent-1", "talent-3"],
+};
+
+const mockShiftListResponse = {
+  items: [],
+  total: 0,
+  nextCursor: null,
+};
+
+function createBaseHandlers() {
+  return [
+    trpcQuery("profile", "getMy", () => ({
+      user: mockUser,
+      profile: mockPlannerProfile,
+    })),
+    trpcQuery("shift", "list", () => mockShiftListResponse),
+    trpcQuery("shift", "calendar", () => []),
+  ];
+}
+
+/**
+ * Default form with talents loaded.
+ * Fill in the form and click "Create Shift" to submit.
+ */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "shift-123" })),
+      ],
+    },
+  },
+};
+
+/**
+ * Loading state - talents are being fetched.
+ * Shows the form with loading indicators.
+ */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", async () => {
+          // Simulate slow network
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return mockTalents;
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Success state - shift created successfully.
+ * The form submits and calls onSuccess callback.
+ */
+export const Success: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "shift-456" })),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for form to be ready
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const canvas = canvasElement;
+
+    // Fill in location
+    const locationInput = canvas.querySelector(
+      'input[placeholder="Enter location"]',
+    ) as unknown as HTMLInputElement | null;
+    if (locationInput) {
+      locationInput.value = "Main Stage";
+      locationInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in task
+    const taskInput = canvas.querySelector(
+      'input[placeholder="Enter task description"]',
+    ) as unknown as HTMLInputElement | null;
+    if (taskInput) {
+      taskInput.value = "Setup and teardown";
+      taskInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in start time
+    const startTimeInput = canvas.querySelector(
+      'input[type="datetime-local"]',
+    ) as unknown as HTMLInputElement | null;
+    if (startTimeInput) {
+      // Set to tomorrow at 9:00 AM
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(9, 0, 0, 0);
+      startTimeInput.value = tomorrow.toISOString().slice(0, 16);
+      startTimeInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in end time
+    const endTimeInputs = canvas.querySelectorAll(
+      'input[type="datetime-local"]',
+    ) as unknown as NodeListOf<HTMLInputElement>;
+    if (endTimeInputs.length > 1) {
+      const endTime = new Date();
+      endTime.setDate(endTime.getDate() + 1);
+      endTime.setHours(17, 0, 0, 0);
+      endTimeInputs[1].value = endTime.toISOString().slice(0, 16);
+      endTimeInputs[1].dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  },
+};
+
+/**
+ * Error state - validation errors from the server.
+ * Shows error banner when submission fails.
+ */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        http.post("*/api/trpc/shift.create", () =>
+          HttpResponse.json(
+            {
+              id: null,
+              error: {
+                message: "End time must be after start time",
+                code: -32603,
+                data: {
+                  code: "BAD_REQUEST",
+                  httpStatus: 400,
+                },
+              },
+            },
+            { status: 400 },
+          ),
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for form to be ready
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const canvas = canvasElement;
+
+    // Fill in location
+    const locationInput = canvas.querySelector(
+      'input[placeholder="Enter location"]',
+    ) as unknown as HTMLInputElement | null;
+    if (locationInput) {
+      locationInput.value = "Main Stage";
+      locationInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in task
+    const taskInput = canvas.querySelector(
+      'input[placeholder="Enter task description"]',
+    ) as unknown as HTMLInputElement | null;
+    if (taskInput) {
+      taskInput.value = "Setup";
+      taskInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in start time
+    const startTimeInput = canvas.querySelector(
+      'input[type="datetime-local"]',
+    ) as unknown as HTMLInputElement | null;
+    if (startTimeInput) {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(9, 0, 0, 0);
+      startTimeInput.value = tomorrow.toISOString().slice(0, 16);
+      startTimeInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Fill in end time (before start time to trigger error)
+    const endTimeInputs = canvas.querySelectorAll(
+      'input[type="datetime-local"]',
+    ) as unknown as NodeListOf<HTMLInputElement>;
+    if (endTimeInputs.length > 1) {
+      const endTime = new Date();
+      endTime.setDate(endTime.getDate() + 1);
+      endTime.setHours(8, 0, 0, 0); // Before start time
+      endTimeInputs[1].value = endTime.toISOString().slice(0, 16);
+      endTimeInputs[1].dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Click submit button
+    const submitButton = canvas.querySelector('button[type="button"]');
+    if (submitButton?.textContent?.includes("Create")) {
+      (submitButton as HTMLButtonElement).click();
+    }
+  },
+};
+
+/**
+ * Form with pre-selected skills and tools.
+ * Shows the form with some options already selected.
+ */
+export const WithSelections: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "shift-789" })),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for form to be ready
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const canvas = canvasElement;
+
+    // Fill in required fields
+    const locationInput = canvas.querySelector(
+      'input[placeholder="Enter location"]',
+    ) as unknown as HTMLInputElement | null;
+    if (locationInput) {
+      locationInput.value = "Catering Area";
+      locationInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    const taskInput = canvas.querySelector(
+      'input[placeholder="Enter task description"]',
+    ) as unknown as HTMLInputElement | null;
+    if (taskInput) {
+      taskInput.value = "Food service";
+      taskInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Set times
+    const startTimeInput = canvas.querySelector(
+      'input[type="datetime-local"]',
+    ) as unknown as HTMLInputElement | null;
+    if (startTimeInput) {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(10, 0, 0, 0);
+      startTimeInput.value = tomorrow.toISOString().slice(0, 16);
+      startTimeInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    const endTimeInputs = canvas.querySelectorAll(
+      'input[type="datetime-local"]',
+    ) as unknown as NodeListOf<HTMLInputElement>;
+    if (endTimeInputs.length > 1) {
+      const endTime = new Date();
+      endTime.setDate(endTime.getDate() + 1);
+      endTime.setHours(14, 0, 0, 0);
+      endTimeInputs[1].value = endTime.toISOString().slice(0, 16);
+      endTimeInputs[1].dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    // Click on skill buttons to select them
+    const buttons = canvas.querySelectorAll('button[type="button"]');
+    for (const button of buttons) {
+      const text = button.textContent?.toLowerCase() || "";
+      if (text.includes("gastro") || text.includes("driver_18plus")) {
+        (button as HTMLButtonElement).click();
+      }
+    }
+
+    // Click on tool buttons to select them
+    for (const button of buttons) {
+      const text = button.textContent?.toLowerCase() || "";
+      if (text.includes("car")) {
+        (button as HTMLButtonElement).click();
+      }
+    }
+  },
+};
+
+/**
+ * Empty talents state - no skills available.
+ * Shows the form without the skills section.
+ */
+export const NoTalents: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", () => []),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "shift-abc" })),
+      ],
+    },
+  },
+};

--- a/src/components/shifts/shift-form.stories.tsx
+++ b/src/components/shifts/shift-form.stories.tsx
@@ -37,6 +37,7 @@ const mockUser = {
   name: "Max Mustermann",
   email: "max@example.com",
   image: "https://i.pravatar.cc/150?u=shift-form",
+  isHeadOf: false,
 };
 
 const mockPlannerProfile = {

--- a/src/components/shifts/shift-form.tsx
+++ b/src/components/shifts/shift-form.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TOOL_OPTIONS, type Tool } from "@/domain/qsum/shifts";
+import { api } from "@/server/api/client";
+import { AlertCircle, Calendar, Check, Clock, Link2, MapPin, Save, X } from "lucide-react";
+import * as React from "react";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Types
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface FormState {
+  location: string;
+  task: string;
+  description: string;
+  notionLink: string;
+  startTime: string;
+  endTime: string;
+  skillIds: string[];
+  tools: Tool[];
+}
+
+interface FieldErrors {
+  location?: string;
+  task?: string;
+  notionLink?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+interface Talent {
+  id: string;
+  category: string;
+  key: string;
+}
+
+const INITIAL_STATE: FormState = {
+  location: "",
+  task: "",
+  description: "",
+  notionLink: "",
+  startTime: "",
+  endTime: "",
+  skillIds: [],
+  tools: [],
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Validation helpers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function validateNotionUrl(url: string): string | undefined {
+  if (!url.trim()) return undefined;
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (host !== "notion.so" && host !== "www.notion.so" && !host.endsWith(".notion.so")) {
+      return "Please enter a valid Notion URL (e.g., notion.so/page)";
+    }
+  } catch {
+    return "Please enter a valid URL";
+  }
+  return undefined;
+}
+
+function validateDateTime(dateTime: string): string | undefined {
+  if (!dateTime) return "Required";
+  const date = new Date(dateTime);
+  if (isNaN(date.getTime())) return "Invalid date/time";
+  return undefined;
+}
+
+function validateTimeRange(startTime: string, endTime: string): string | undefined {
+  if (!startTime || !endTime) return undefined;
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  if (end <= start) return "End time must be after start time";
+  return undefined;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
+  const { data: talents = [] } = api.profile.listTalents.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const create = api.shift.create.useMutation();
+
+  const [form, setForm] = React.useState<FormState>(INITIAL_STATE);
+  const [errors, setErrors] = React.useState<FieldErrors>({});
+
+  const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    // Clear error when field changes
+    if (key in errors) {
+      setErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  };
+
+  const toggleSkill = (talentId: string) => {
+    setForm((prev) => ({
+      ...prev,
+      skillIds: prev.skillIds.includes(talentId)
+        ? prev.skillIds.filter((id) => id !== talentId)
+        : [...prev.skillIds, talentId],
+    }));
+  };
+
+  const toggleTool = (tool: Tool) => {
+    setForm((prev) => ({
+      ...prev,
+      tools: prev.tools.includes(tool)
+        ? prev.tools.filter((t) => t !== tool)
+        : [...prev.tools, tool],
+    }));
+  };
+
+  const validateForm = (): boolean => {
+    const fieldErrors: FieldErrors = {
+      location: !form.location.trim() ? "Location is required" : undefined,
+      task: !form.task.trim() ? "Task is required" : undefined,
+      notionLink: validateNotionUrl(form.notionLink),
+      startTime: validateDateTime(form.startTime),
+      endTime: validateDateTime(form.endTime),
+    };
+
+    const timeRangeError = validateTimeRange(form.startTime, form.endTime);
+    if (timeRangeError && !fieldErrors.endTime) {
+      fieldErrors.endTime = timeRangeError;
+    }
+
+    setErrors(fieldErrors);
+    return !Object.values(fieldErrors).some(Boolean);
+  };
+
+  const onSubmit = () => {
+    if (!validateForm()) return;
+
+    create.mutate(
+      {
+        location: form.location.trim(),
+        task: form.task.trim(),
+        description: form.description.trim() || null,
+        notionLink: form.notionLink.trim() || null,
+        startTime: new Date(form.startTime),
+        endTime: new Date(form.endTime),
+        skillIds: form.skillIds,
+        tools: form.tools,
+      },
+      {
+        onSuccess: () => {
+          setForm(INITIAL_STATE);
+          onSuccess?.();
+        },
+      },
+    );
+  };
+
+  const onCancel = () => {
+    setForm(INITIAL_STATE);
+    setErrors({});
+  };
+
+  const canSubmit =
+    !!form.location.trim() &&
+    !!form.task.trim() &&
+    !!form.startTime &&
+    !!form.endTime &&
+    !create.isPending;
+
+  // Group talents by category
+  const talentsByCategory = React.useMemo(() => {
+    const grouped = new Map<string, Talent[]>();
+    for (const talent of talents) {
+      const existing = grouped.get(talent.category) ?? [];
+      existing.push(talent);
+      grouped.set(talent.category, existing);
+    }
+    return grouped;
+  }, [talents]);
+
+  return (
+    <div className="grid gap-6">
+      {/* Error Banner */}
+      {create.error?.message && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {create.error.message}
+        </div>
+      )}
+
+      {/* Basic Information */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Basic Information</h2>
+        <div className="grid gap-4">
+          {/* Location */}
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Location
+            </Label>
+            <div className="flex items-center gap-3">
+              <MapPin className="h-5 w-5 text-muted-foreground" />
+              <Input
+                className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+                placeholder="Enter location"
+                value={form.location}
+                onChange={(e) => updateField("location", e.target.value)}
+              />
+            </div>
+            {errors.location && (
+              <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                <AlertCircle className="h-3 w-3" />
+                {errors.location}
+              </div>
+            )}
+          </div>
+
+          {/* Task */}
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Task
+            </Label>
+            <Input
+              className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+              placeholder="Enter task description"
+              value={form.task}
+              onChange={(e) => updateField("task", e.target.value)}
+            />
+            {errors.task && (
+              <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                <AlertCircle className="h-3 w-3" />
+                {errors.task}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Time Schedule */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Time Schedule</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {/* Start Time */}
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Start Time
+            </Label>
+            <div className="flex items-center gap-3">
+              <Calendar className="h-5 w-5 text-muted-foreground" />
+              <Input
+                type="datetime-local"
+                aria-label="Start time"
+                className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+                value={form.startTime}
+                onChange={(e) => updateField("startTime", e.target.value)}
+              />
+            </div>
+            {errors.startTime && (
+              <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                <AlertCircle className="h-3 w-3" />
+                {errors.startTime}
+              </div>
+            )}
+          </div>
+
+          {/* End Time */}
+          <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              End Time
+            </Label>
+            <div className="flex items-center gap-3">
+              <Clock className="h-5 w-5 text-muted-foreground" />
+              <Input
+                type="datetime-local"
+                aria-label="End time"
+                className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+                value={form.endTime}
+                onChange={(e) => updateField("endTime", e.target.value)}
+              />
+            </div>
+            {errors.endTime && (
+              <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                <AlertCircle className="h-3 w-3" />
+                {errors.endTime}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Skills */}
+      {talents.length > 0 && (
+        <div>
+          <div className="mb-3 flex items-end justify-between px-1">
+            <h2 className="text-lg font-bold text-foreground">Required Skills</h2>
+            <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+              SELECT ALL THAT APPLY
+            </span>
+          </div>
+          <div className="grid gap-3">
+            {Array.from(talentsByCategory.entries()).map(([category, categoryTalents]) => (
+              <div
+                key={category}
+                className="rounded-2xl border border-border bg-white p-4 shadow-sm"
+              >
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {category}
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {categoryTalents.map((talent) => (
+                    <button
+                      key={talent.id}
+                      type="button"
+                      onClick={() => toggleSkill(talent.id)}
+                      className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors ${
+                        form.skillIds.includes(talent.id)
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-background text-foreground hover:bg-accent"
+                      }`}
+                    >
+                      {form.skillIds.includes(talent.id) && <Check className="h-4 w-4" />}
+                      {talent.key}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tools */}
+      <div>
+        <div className="mb-3 flex items-end justify-between px-1">
+          <h2 className="text-lg font-bold text-foreground">Required Tools</h2>
+          <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+            SELECT ALL THAT APPLY
+          </span>
+        </div>
+        <div className="rounded-2xl border border-border bg-white p-4 shadow-sm">
+          <div className="flex flex-wrap gap-2">
+            {TOOL_OPTIONS.filter((t) => t.value !== "none").map((tool) => (
+              <button
+                key={tool.value}
+                type="button"
+                onClick={() => toggleTool(tool.value)}
+                className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors ${
+                  form.tools.includes(tool.value)
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background text-foreground hover:bg-accent"
+                }`}
+              >
+                {form.tools.includes(tool.value) && <Check className="h-4 w-4" />}
+                {tool.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Notion Link */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Documentation</h2>
+        <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+          <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            Notion Link
+          </Label>
+          <div className="flex items-center gap-3">
+            <Link2 className="h-5 w-5 text-muted-foreground" />
+            <Input
+              type="url"
+              className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
+              placeholder="https://notion.so/..."
+              value={form.notionLink}
+              onChange={(e) => updateField("notionLink", e.target.value)}
+            />
+          </div>
+          {errors.notionLink && (
+            <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+              <AlertCircle className="h-3 w-3" />
+              {errors.notionLink}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Description */}
+      <div>
+        <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Description</h2>
+        <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+          <textarea
+            className="min-h-[120px] w-full resize-none rounded-xl border-0 bg-transparent p-0 text-sm font-medium text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
+            placeholder="Enter detailed description of the shift..."
+            value={form.description}
+            onChange={(e) => updateField("description", e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex gap-3">
+        <Button
+          onClick={onCancel}
+          variant="outline"
+          disabled={create.isPending}
+          className="flex h-14 flex-1 items-center justify-center gap-2 rounded-xl text-lg font-semibold"
+        >
+          <X className="h-5 w-5" />
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={!canSubmit}
+          className="flex h-14 flex-1 items-center justify-center gap-2 rounded-xl text-lg font-semibold shadow-md"
+        >
+          <Save className="h-5 w-5" />
+          {create.isPending ? "Creating..." : "Create Shift"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shifts/shift-form.tsx
+++ b/src/components/shifts/shift-form.tsx
@@ -328,13 +328,13 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
 
       {/* Skills */}
       {talents.length > 0 && (
-        <div>
-          <div className="mb-3 flex items-end justify-between px-1">
+        <fieldset className="border-0 p-0" aria-labelledby="shift-skillIds-legend">
+          <legend id="shift-skillIds-legend" className="mb-3 flex items-end justify-between px-1">
             <h2 className="text-lg font-bold text-foreground">Required Skills</h2>
             <span className="text-xs font-semibold tracking-wider text-muted-foreground">
               SELECT ALL THAT APPLY
             </span>
-          </div>
+          </legend>
           <div className="grid gap-3">
             {Array.from(talentsByCategory.entries()).map(([category, categoryTalents]) => (
               <div
@@ -364,17 +364,17 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
               </div>
             ))}
           </div>
-        </div>
+        </fieldset>
       )}
 
       {/* Tools */}
-      <div>
-        <div className="mb-3 flex items-end justify-between px-1">
+      <fieldset className="border-0 p-0" aria-labelledby="shift-tools-legend">
+        <legend id="shift-tools-legend" className="mb-3 flex items-end justify-between px-1">
           <h2 className="text-lg font-bold text-foreground">Required Tools</h2>
           <span className="text-xs font-semibold tracking-wider text-muted-foreground">
             SELECT ALL THAT APPLY
           </span>
-        </div>
+        </legend>
         <div className="rounded-2xl border border-border bg-white p-4 shadow-sm">
           <div className="flex flex-wrap gap-2">
             {TOOL_OPTIONS.map((tool) => (
@@ -394,7 +394,7 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
             ))}
           </div>
         </div>
-      </div>
+      </fieldset>
 
       {/* Notion Link */}
       <div>
@@ -430,7 +430,14 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
       <div>
         <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Description</h2>
         <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
+          <Label
+            htmlFor="shift-description"
+            className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+          >
+            Description
+          </Label>
           <textarea
+            id="shift-description"
             className="min-h-[120px] w-full resize-none rounded-xl border-0 bg-transparent p-0 text-sm font-medium text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
             placeholder="Enter detailed description of the shift..."
             value={form.description}

--- a/src/components/shifts/shift-form.tsx
+++ b/src/components/shifts/shift-form.tsx
@@ -81,6 +81,17 @@ function validateTimeRange(startTime: string, endTime: string): string | undefin
   return undefined;
 }
 
+const SLOT_INTERVAL_MS = 30 * 60 * 1000;
+
+/** Build 30-min slots from start to end with a given headcount (for create payload). */
+function buildSlotsForRange(startTime: Date, endTime: Date, headcount: number) {
+  const slots: { slotTime: Date; headcount: number }[] = [];
+  for (let ts = startTime.getTime(); ts < endTime.getTime(); ts += SLOT_INTERVAL_MS) {
+    slots.push({ slotTime: new Date(ts), headcount });
+  }
+  return slots;
+}
+
 /* ──────────────────────────────────────────────────────────────────────────
  * Main Component
  * ────────────────────────────────────────────────────────────────────────── */
@@ -142,14 +153,17 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
   const onSubmit = () => {
     if (!validateForm()) return;
 
+    const start = new Date(form.startTime);
+    const end = new Date(form.endTime);
     create.mutate(
       {
         location: form.location.trim(),
         task: form.task.trim(),
         description: form.description.trim() || null,
         notionLink: form.notionLink.trim() || null,
-        startTime: new Date(form.startTime),
-        endTime: new Date(form.endTime),
+        startTime: start,
+        endTime: end,
+        slots: buildSlotsForRange(start, end, 1),
         skillIds: form.skillIds,
         tools: form.tools,
       },
@@ -201,12 +215,16 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
         <div className="grid gap-4">
           {/* Location */}
           <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
-            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            <Label
+              htmlFor="shift-location"
+              className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+            >
               Location
             </Label>
             <div className="flex items-center gap-3">
               <MapPin className="h-5 w-5 text-muted-foreground" />
               <Input
+                id="shift-location"
                 className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
                 placeholder="Enter location"
                 value={form.location}
@@ -223,10 +241,14 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
 
           {/* Task */}
           <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
-            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            <Label
+              htmlFor="shift-task"
+              className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+            >
               Task
             </Label>
             <Input
+              id="shift-task"
               className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
               placeholder="Enter task description"
               value={form.task}
@@ -248,13 +270,18 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
         <div className="grid gap-4 sm:grid-cols-2">
           {/* Start Time */}
           <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
-            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            <Label
+              htmlFor="shift-startTime"
+              className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+            >
               Start Time
             </Label>
             <div className="flex items-center gap-3">
               <Calendar className="h-5 w-5 text-muted-foreground" />
               <Input
+                id="shift-startTime"
                 type="datetime-local"
+                step={1800}
                 aria-label="Start time"
                 className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
                 value={form.startTime}
@@ -271,13 +298,18 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
 
           {/* End Time */}
           <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
-            <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            <Label
+              htmlFor="shift-endTime"
+              className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+            >
               End Time
             </Label>
             <div className="flex items-center gap-3">
               <Clock className="h-5 w-5 text-muted-foreground" />
               <Input
+                id="shift-endTime"
                 type="datetime-local"
+                step={1800}
                 aria-label="End time"
                 className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
                 value={form.endTime}
@@ -345,7 +377,7 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
         </div>
         <div className="rounded-2xl border border-border bg-white p-4 shadow-sm">
           <div className="flex flex-wrap gap-2">
-            {TOOL_OPTIONS.filter((t) => t.value !== "none").map((tool) => (
+            {TOOL_OPTIONS.map((tool) => (
               <button
                 key={tool.value}
                 type="button"
@@ -368,12 +400,16 @@ export function ShiftForm({ onSuccess }: { onSuccess?: () => void }) {
       <div>
         <h2 className="mb-3 px-1 text-lg font-bold text-foreground">Documentation</h2>
         <div className="grid gap-2 rounded-2xl border border-border bg-white p-4 shadow-sm">
-          <Label className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          <Label
+            htmlFor="shift-notionLink"
+            className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+          >
             Notion Link
           </Label>
           <div className="flex items-center gap-3">
             <Link2 className="h-5 w-5 text-muted-foreground" />
             <Input
+              id="shift-notionLink"
               type="url"
               className="h-11 rounded-xl border-0 bg-transparent p-0 text-sm font-medium focus-visible:ring-0"
               placeholder="https://notion.so/..."

--- a/src/components/shifts/shift-list.stories.tsx
+++ b/src/components/shifts/shift-list.stories.tsx
@@ -41,6 +41,7 @@ const mockUser = {
   name: "Max Mustermann",
   email: "max@example.com",
   image: "https://i.pravatar.cc/150?u=shift-list",
+  isHeadOf: false,
 };
 
 const mockPlannerProfile = {
@@ -240,10 +241,10 @@ export const InlineEditing: Story = {
     // Wait for the component to render
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    // Find and click the edit button on the first row
+    // Find and click the edit button on the first shift (mock shift id is "shift-1")
     const editButton =
-      canvasElement.querySelector('[data-testid="edit-shift-1"]') ??
-      canvasElement.querySelector('button[title="Edit"]');
+      canvasElement.querySelector('[data-testid="edit-shift-shift-1"]') ??
+      canvasElement.querySelector('button[aria-label="Edit shift"]');
 
     if (editButton) {
       (editButton as HTMLButtonElement).click();

--- a/src/components/shifts/shift-list.stories.tsx
+++ b/src/components/shifts/shift-list.stories.tsx
@@ -1,0 +1,338 @@
+/**
+ * Stories for the ShiftList component.
+ *
+ * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
+ * Demonstrates empty state, loading state, populated state, and inline editing.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { trpcQuery } from "../../../.storybook/utils/trpc-helpers";
+import { ShiftList } from "./shift-list";
+
+const meta = {
+  title: "Shifts/ShiftList",
+  component: ShiftList,
+  parameters: {
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ShiftList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Mock Data
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const mockTalents = [
+  { id: "driver_18plus", category: "driver_license", key: "driver_18plus" },
+  { id: "driver_21plus", category: "driver_license", key: "driver_21plus" },
+  { id: "gastro", category: "gastronomy", key: "gastro" },
+  { id: "first_aid", category: "medical", key: "first_aid" },
+  { id: "security", category: "operations", key: "security" },
+];
+
+const mockUser = {
+  id: "user-1",
+  name: "Max Mustermann",
+  email: "max@example.com",
+  image: "https://i.pravatar.cc/150?u=shift-list",
+};
+
+const mockPlannerProfile = {
+  id: "profile-1",
+  userId: "user-1",
+  status: "active" as const,
+  division: "chair" as const,
+  team: "board" as const,
+  lastActiveYear: 2025,
+  teamOther: null,
+  phoneNumber: null,
+  privateEmail: null,
+  linkedInUrl: null,
+  talentIds: ["driver_18plus", "driver_21plus"],
+};
+
+const mockShifts = [
+  {
+    id: "shift-1",
+    location: "Munich Central Station",
+    task: "Registration Desk",
+    description: "Handle participant check-ins and distribute badges",
+    notionLink: "https://notion.so/shift-1",
+    startTime: new Date("2026-04-09T08:00:00"),
+    endTime: new Date("2026-04-09T12:00:00"),
+    createdBy: "user-1",
+    createdAt: new Date("2026-03-01T10:00:00"),
+    slotSummary: {
+      totalHeadcount: 4,
+    },
+  },
+  {
+    id: "shift-2",
+    location: "Conference Hall A",
+    task: "Stage Setup",
+    description: "Assist with audio/visual equipment setup",
+    notionLink: null,
+    startTime: new Date("2026-04-09T06:00:00"),
+    endTime: new Date("2026-04-09T09:00:00"),
+    createdBy: "user-1",
+    createdAt: new Date("2026-03-01T11:00:00"),
+    slotSummary: {
+      totalHeadcount: 2,
+    },
+  },
+  {
+    id: "shift-3",
+    location: "Catering Area",
+    task: "Food Service",
+    description: "Serve meals and manage dietary requirements",
+    notionLink: "https://notion.so/shift-3",
+    startTime: new Date("2026-04-09T12:00:00"),
+    endTime: new Date("2026-04-09T15:00:00"),
+    createdBy: "user-2",
+    createdAt: new Date("2026-03-02T09:00:00"),
+    slotSummary: {
+      totalHeadcount: 6,
+    },
+  },
+  {
+    id: "shift-4",
+    location: "Parking Lot",
+    task: "Traffic Direction",
+    description: "Guide vehicles and manage parking flow",
+    notionLink: null,
+    startTime: new Date("2026-04-10T07:00:00"),
+    endTime: new Date("2026-04-10T19:00:00"),
+    createdBy: "user-1",
+    createdAt: new Date("2026-03-03T14:00:00"),
+    slotSummary: {
+      totalHeadcount: 3,
+    },
+  },
+];
+
+function createBaseHandlers() {
+  return [
+    trpcQuery("profile", "getMy", () => ({
+      user: mockUser,
+      profile: mockPlannerProfile,
+    })),
+    trpcQuery("shift", "list", () => ({
+      items: mockShifts,
+      total: mockShifts.length,
+      nextCursor: null,
+    })),
+    trpcQuery("shift", "calendar", () => []),
+  ];
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Stories
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Empty state - no shifts available.
+ */
+export const Empty: Story = {
+  args: {
+    shifts: [],
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Loading state - shows skeleton placeholders.
+ */
+export const Loading: Story = {
+  args: {
+    shifts: [],
+    isLoading: true,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        ...createBaseHandlers(),
+        trpcQuery("profile", "listTalents", async () => {
+          // Simulate slow network for talents
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return mockTalents;
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Populated state - multiple shifts with different data.
+ */
+export const Populated: Story = {
+  args: {
+    shifts: mockShifts,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Single shift - minimal data.
+ */
+export const SingleShift: Story = {
+  args: {
+    shifts: [mockShifts[0]],
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Many shifts - demonstrates scrolling behavior.
+ */
+export const ManyShifts: Story = {
+  args: {
+    shifts: Array.from({ length: 15 }, (_, i) => ({
+      ...mockShifts[i % mockShifts.length],
+      id: `shift-${i + 1}`,
+      location: `${mockShifts[i % mockShifts.length].location} ${i + 1}`,
+      createdAt: new Date(Date.now() - i * 86400000),
+    })),
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Inline editing - demonstrates the edit mode for the first shift.
+ * This story shows the inline editing interface with input fields.
+ */
+export const InlineEditing: Story = {
+  args: {
+    shifts: mockShifts,
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // Wait for the component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Find and click the edit button on the first row
+    const editButton =
+      canvasElement.querySelector('[data-testid="edit-shift-1"]') ??
+      canvasElement.querySelector('button[title="Edit"]');
+
+    if (editButton) {
+      (editButton as HTMLButtonElement).click();
+    }
+  },
+};
+
+/**
+ * With callbacks - demonstrates edit and delete handlers.
+ */
+export const WithCallbacks: Story = {
+  args: {
+    shifts: mockShifts,
+    isLoading: false,
+    onEdit: (shift) => {
+      console.log("Edit shift:", shift);
+    },
+    onDelete: (shiftId) => {
+      console.log("Delete shift:", shiftId);
+    },
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Long content - demonstrates text wrapping for long locations and tasks.
+ */
+export const LongContent: Story = {
+  args: {
+    shifts: [
+      {
+        ...mockShifts[0],
+        location:
+          "Munich Central Station - Main Entrance Hall, Left Wing, Near the Information Desk",
+        task: "Registration Desk - Handle participant check-ins, distribute badges, manage VIP list, and coordinate with security team for access control",
+      },
+    ],
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Zero headcount - shows shift with no assigned staff.
+ */
+export const ZeroHeadcount: Story = {
+  args: {
+    shifts: [
+      {
+        ...mockShifts[0],
+        slotSummary: {
+          totalHeadcount: 0,
+        },
+      },
+    ],
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};
+
+/**
+ * Multi-day shift - demonstrates time formatting across days.
+ */
+export const MultiDayShift: Story = {
+  args: {
+    shifts: [
+      {
+        ...mockShifts[3],
+        startTime: new Date("2026-04-09T22:00:00"),
+        endTime: new Date("2026-04-10T06:00:00"),
+      },
+    ],
+    isLoading: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [...createBaseHandlers(), trpcQuery("profile", "listTalents", () => mockTalents)],
+    },
+  },
+};

--- a/src/components/shifts/shift-list.tsx
+++ b/src/components/shifts/shift-list.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { api } from "@/server/api/client";
+
 import {
   AlertCircle,
   AlertTriangle,
@@ -52,17 +52,6 @@ interface ShiftListProps {
   isPlanner?: boolean;
   onEdit?: (shift: ShiftWithDetails) => void;
   onDelete?: (shiftId: string) => void;
-}
-
-interface ShiftRowProps {
-  shift: Shift;
-  talents: Talent[];
-  isEditing: boolean;
-  onEditStart: () => void;
-  onEditSave: (shiftId: string, data: { location: string; task: string }) => void;
-  onEditCancel: () => void;
-  onDelete: (shiftId: string) => void;
-  isSaving?: boolean;
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
@@ -141,26 +130,24 @@ function LoadingSkeleton() {
   return (
     <div className="space-y-3">
       {/* Header Skeleton */}
-      <div className="grid grid-cols-6 gap-4 rounded-lg bg-muted/50 px-4 py-3">
+      <div className="grid grid-cols-[repeat(5,1fr)] gap-4 rounded-lg bg-muted/50 px-4 py-3">
         <div className="h-4 w-20 animate-pulse rounded bg-muted" />
         <div className="h-4 w-24 animate-pulse rounded bg-muted" />
         <div className="h-4 w-32 animate-pulse rounded bg-muted" />
         <div className="h-4 w-16 animate-pulse rounded bg-muted" />
         <div className="h-4 w-20 animate-pulse rounded bg-muted" />
-        <div className="h-4 w-16 animate-pulse rounded bg-muted" />
       </div>
 
       {/* Row Skeletons */}
       {Array.from({ length: 3 }).map((_, i) => (
         <div
           key={i}
-          className="grid grid-cols-6 gap-4 rounded-xl border border-border bg-white p-4 shadow-sm"
+          className="grid grid-cols-[repeat(5,1fr)] gap-4 rounded-xl border border-border bg-white p-4 shadow-sm"
         >
           <div className="h-5 w-full animate-pulse rounded bg-muted" />
           <div className="h-5 w-full animate-pulse rounded bg-muted" />
           <div className="h-5 w-full animate-pulse rounded bg-muted" />
           <div className="h-5 w-12 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-full animate-pulse rounded bg-muted" />
           <div className="h-5 w-20 animate-pulse rounded bg-muted" />
         </div>
       ))}
@@ -172,7 +159,7 @@ function LoadingSkeleton() {
  * Skills Badge Component
  * ────────────────────────────────────────────────────────────────────────── */
 
-function SkillsBadge({ skillIds, talents }: { skillIds: string[]; talents: Talent[] }) {
+function _SkillsBadge({ skillIds, talents }: { skillIds: string[]; talents: Talent[] }) {
   if (skillIds.length === 0) {
     return <span className="text-sm text-muted-foreground">-</span>;
   }
@@ -202,13 +189,12 @@ function SkillsBadge({ skillIds, talents }: { skillIds: string[]; talents: Talen
 
 interface InlineEditRowProps {
   shift: Shift;
-  talents: Talent[];
   onSave: (shiftId: string, data: { location: string; task: string }) => void;
   onCancel: () => void;
   isSaving?: boolean;
 }
 
-function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEditRowProps) {
+function InlineEditRow({ shift, onSave, onCancel, isSaving }: InlineEditRowProps) {
   const [location, setLocation] = React.useState(shift.location);
   const [task, setTask] = React.useState(shift.task);
   const [errors, setErrors] = React.useState<{ location?: string; task?: string }>({});
@@ -305,14 +291,11 @@ function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEdi
         {shift.slotSummary.totalHeadcount === 0 ? (
           <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
             <AlertTriangle className="h-3 w-3" />
-            <span>No slots</span>
+            <span>No headcount</span>
           </div>
         ) : (
           <span className="text-sm font-medium">{shift.slotSummary.totalHeadcount}</span>
         )}
-      </td>
-      <td className="px-4 py-3">
-        <SkillsBadge skillIds={[]} talents={talents} />
       </td>
       <td className="px-4 py-3">
         <div className="flex items-center gap-1">
@@ -322,6 +305,7 @@ function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEdi
             className="h-8 w-8"
             onClick={handleSave}
             disabled={isSaving}
+            aria-label="Save"
           >
             <Check className="h-4 w-4 text-green-600" />
           </Button>
@@ -331,6 +315,7 @@ function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEdi
             className="h-8 w-8"
             onClick={onCancel}
             disabled={isSaving}
+            aria-label="Cancel"
           >
             <X className="h-4 w-4 text-destructive" />
           </Button>
@@ -346,7 +331,6 @@ function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEdi
 
 interface ShiftRowProps {
   shift: Shift;
-  talents: Talent[];
   isEditing: boolean;
   isPlanner: boolean;
   onEditStart: () => void;
@@ -358,7 +342,6 @@ interface ShiftRowProps {
 
 function ShiftRow({
   shift,
-  talents,
   isEditing,
   isPlanner,
   onEditStart,
@@ -371,7 +354,6 @@ function ShiftRow({
     return (
       <InlineEditRow
         shift={shift}
-        talents={talents}
         onSave={onEditSave}
         onCancel={onEditCancel}
         isSaving={isSaving}
@@ -403,19 +385,23 @@ function ShiftRow({
         {shift.slotSummary.totalHeadcount === 0 ? (
           <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
             <AlertTriangle className="h-3 w-3" />
-            <span>No slots</span>
+            <span>No headcount</span>
           </div>
         ) : (
           <span className="text-sm font-medium">{shift.slotSummary.totalHeadcount}</span>
         )}
       </td>
-      <td className="px-4 py-3">
-        <SkillsBadge skillIds={[]} talents={talents} />
-      </td>
-      <td className="px-4 py-3">
-        {isPlanner && (
+      {isPlanner && (
+        <td className="px-4 py-3">
           <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={onEditStart}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onEditStart}
+              aria-label="Edit shift"
+              data-testid={`edit-shift-${shift.id}`}
+            >
               <Pencil className="h-4 w-4" />
             </Button>
             <Button
@@ -423,12 +409,13 @@ function ShiftRow({
               size="icon"
               className="h-8 w-8 text-destructive hover:text-destructive"
               onClick={() => onDelete(shift.id)}
+              aria-label="Delete shift"
             >
               <Trash2 className="h-4 w-4" />
             </Button>
           </div>
-        )}
-      </td>
+        </td>
+      )}
     </tr>
   );
 }
@@ -444,10 +431,6 @@ export function ShiftList({
   onEdit,
   onDelete,
 }: ShiftListProps) {
-  const { data: talents = [] } = api.profile.listTalents.useQuery(undefined, {
-    refetchOnWindowFocus: false,
-  });
-
   const [editingShiftId, setEditingShiftId] = React.useState<string | null>(null);
   const [isSaving, setIsSaving] = React.useState(false);
 
@@ -511,9 +494,6 @@ export function ShiftList({
               <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 Headcount
               </th>
-              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Skills
-              </th>
               {isPlanner && (
                 <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Actions
@@ -526,7 +506,6 @@ export function ShiftList({
               <ShiftRow
                 key={shift.id}
                 shift={shift}
-                talents={talents}
                 isEditing={editingShiftId === shift.id}
                 isPlanner={isPlanner}
                 onEditStart={() => handleEditStart(shift.id)}

--- a/src/components/shifts/shift-list.tsx
+++ b/src/components/shifts/shift-list.tsx
@@ -305,7 +305,7 @@ function InlineEditRow({ shift, onSave, onCancel, isSaving }: InlineEditRowProps
             className="h-8 w-8"
             onClick={handleSave}
             disabled={isSaving}
-            aria-label="Save"
+            aria-label="Save changes"
           >
             <Check className="h-4 w-4 text-green-600" />
           </Button>
@@ -315,7 +315,7 @@ function InlineEditRow({ shift, onSave, onCancel, isSaving }: InlineEditRowProps
             className="h-8 w-8"
             onClick={onCancel}
             disabled={isSaving}
-            aria-label="Cancel"
+            aria-label="Cancel editing"
           >
             <X className="h-4 w-4 text-destructive" />
           </Button>

--- a/src/components/shifts/shift-list.tsx
+++ b/src/components/shifts/shift-list.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api } from "@/server/api/client";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Calendar,
+  Check,
+  Clock,
+  MapPin,
+  Pencil,
+  Trash2,
+  X,
+} from "lucide-react";
+import * as React from "react";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Types
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface Shift {
+  id: string;
+  location: string;
+  task: string;
+  description: string | null;
+  notionLink: string | null;
+  startTime: Date;
+  endTime: Date;
+  createdBy: string;
+  createdAt: Date;
+  slotSummary: {
+    totalHeadcount: number;
+  };
+}
+
+interface ShiftWithDetails extends Shift {
+  skillIds: string[];
+  tools: string[];
+}
+
+interface Talent {
+  id: string;
+  category: string;
+  key: string;
+}
+
+interface ShiftListProps {
+  shifts: Shift[];
+  isLoading?: boolean;
+  isPlanner?: boolean;
+  onEdit?: (shift: ShiftWithDetails) => void;
+  onDelete?: (shiftId: string) => void;
+}
+
+interface ShiftRowProps {
+  shift: Shift;
+  talents: Talent[];
+  isEditing: boolean;
+  onEditStart: () => void;
+  onEditSave: (shiftId: string, data: { location: string; task: string }) => void;
+  onEditCancel: () => void;
+  onDelete: (shiftId: string) => void;
+  isSaving?: boolean;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Helper Functions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function formatTimeRange(startTime: Date, endTime: Date): string {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+
+  const formatTime = (date: Date) =>
+    date.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+
+  const startDate = formatDate(start);
+  const endDate = formatDate(end);
+  const startTimeStr = formatTime(start);
+  const endTimeStr = formatTime(end);
+
+  if (startDate === endDate) {
+    return `${startDate}, ${startTimeStr} - ${endTimeStr}`;
+  }
+  return `${startDate} ${startTimeStr} - ${endDate} ${endTimeStr}`;
+}
+
+function formatDuration(startTime: Date, endTime: Date): string {
+  const start = new Date(startTime).getTime();
+  const end = new Date(endTime).getTime();
+  const durationMs = end - start;
+  const hours = Math.floor(durationMs / (1000 * 60 * 60));
+  const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+  return `${hours}h ${minutes}m`;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Empty State Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-muted/30 p-12 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <Calendar className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h2 className="mb-2 text-lg font-semibold text-foreground">No shifts yet</h2>
+      <p className="mb-6 max-w-sm text-sm text-muted-foreground">
+        Get started by creating your first shift. Shifts help you organize tasks and assign team
+        members.
+      </p>
+      <p className="text-xs text-muted-foreground">Use the form above to create a new shift</p>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Loading Skeleton Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-3">
+      {/* Header Skeleton */}
+      <div className="grid grid-cols-6 gap-4 rounded-lg bg-muted/50 px-4 py-3">
+        <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+      </div>
+
+      {/* Row Skeletons */}
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-6 gap-4 rounded-xl border border-border bg-white p-4 shadow-sm"
+        >
+          <div className="h-5 w-full animate-pulse rounded bg-muted" />
+          <div className="h-5 w-full animate-pulse rounded bg-muted" />
+          <div className="h-5 w-full animate-pulse rounded bg-muted" />
+          <div className="h-5 w-12 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-full animate-pulse rounded bg-muted" />
+          <div className="h-5 w-20 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Skills Badge Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function SkillsBadge({ skillIds, talents }: { skillIds: string[]; talents: Talent[] }) {
+  if (skillIds.length === 0) {
+    return <span className="text-sm text-muted-foreground">-</span>;
+  }
+
+  const skillNames = skillIds.map((id) => talents.find((t) => t.id === id)?.key ?? id).slice(0, 3);
+
+  const remaining = skillIds.length - skillNames.length;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {skillNames.map((name, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center rounded-full border border-border bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground"
+        >
+          {name}
+        </span>
+      ))}
+      {remaining > 0 && <span className="text-xs text-muted-foreground">+{remaining}</span>}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Inline Edit Row Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface InlineEditRowProps {
+  shift: Shift;
+  talents: Talent[];
+  onSave: (shiftId: string, data: { location: string; task: string }) => void;
+  onCancel: () => void;
+  isSaving?: boolean;
+}
+
+function InlineEditRow({ shift, talents, onSave, onCancel, isSaving }: InlineEditRowProps) {
+  const [location, setLocation] = React.useState(shift.location);
+  const [task, setTask] = React.useState(shift.task);
+  const [errors, setErrors] = React.useState<{ location?: string; task?: string }>({});
+
+  const handleSave = () => {
+    const newErrors: { location?: string; task?: string } = {};
+
+    if (!location.trim()) {
+      newErrors.location = "Location is required";
+    }
+    if (!task.trim()) {
+      newErrors.task = "Task is required";
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    onSave(shift.id, { location: location.trim(), task: task.trim() });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      onCancel();
+    }
+  };
+
+  return (
+    <tr className="bg-accent/30">
+      <td className="px-4 py-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            <Input
+              value={location}
+              onChange={(e) => {
+                setLocation(e.target.value);
+                if (errors.location) {
+                  setErrors((prev) => ({ ...prev, location: undefined }));
+                }
+              }}
+              onKeyDown={handleKeyDown}
+              className="h-8 text-sm"
+              placeholder="Enter location"
+              disabled={isSaving}
+              autoFocus
+            />
+          </div>
+          {errors.location && (
+            <div className="flex items-center gap-1 text-xs text-destructive">
+              <AlertCircle className="h-3 w-3" />
+              {errors.location}
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="space-y-1">
+          <Input
+            value={task}
+            onChange={(e) => {
+              setTask(e.target.value);
+              if (errors.task) {
+                setErrors((prev) => ({ ...prev, task: undefined }));
+              }
+            }}
+            onKeyDown={handleKeyDown}
+            className="h-8 text-sm"
+            placeholder="Enter task"
+            disabled={isSaving}
+          />
+          {errors.task && (
+            <div className="flex items-center gap-1 text-xs text-destructive">
+              <AlertCircle className="h-3 w-3" />
+              {errors.task}
+            </div>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Clock className="h-4 w-4" />
+          <span>{formatTimeRange(shift.startTime, shift.endTime)}</span>
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          {formatDuration(shift.startTime, shift.endTime)}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        {shift.slotSummary.totalHeadcount === 0 ? (
+          <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+            <AlertTriangle className="h-3 w-3" />
+            <span>No slots</span>
+          </div>
+        ) : (
+          <span className="text-sm font-medium">{shift.slotSummary.totalHeadcount}</span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        <SkillsBadge skillIds={[]} talents={talents} />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            <Check className="h-4 w-4 text-green-600" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            <X className="h-4 w-4 text-destructive" />
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Shift Row Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface ShiftRowProps {
+  shift: Shift;
+  talents: Talent[];
+  isEditing: boolean;
+  isPlanner: boolean;
+  onEditStart: () => void;
+  onEditSave: (shiftId: string, data: { location: string; task: string }) => void;
+  onEditCancel: () => void;
+  onDelete: (shiftId: string) => void;
+  isSaving?: boolean;
+}
+
+function ShiftRow({
+  shift,
+  talents,
+  isEditing,
+  isPlanner,
+  onEditStart,
+  onEditSave,
+  onEditCancel,
+  onDelete,
+  isSaving,
+}: ShiftRowProps) {
+  if (isEditing) {
+    return (
+      <InlineEditRow
+        shift={shift}
+        talents={talents}
+        onSave={onEditSave}
+        onCancel={onEditCancel}
+        isSaving={isSaving}
+      />
+    );
+  }
+
+  return (
+    <tr className="group transition-colors hover:bg-muted/50">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <MapPin className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium text-foreground">{shift.location}</span>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <span className="text-foreground">{shift.task}</span>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Clock className="h-4 w-4" />
+          <span>{formatTimeRange(shift.startTime, shift.endTime)}</span>
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          {formatDuration(shift.startTime, shift.endTime)}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        {shift.slotSummary.totalHeadcount === 0 ? (
+          <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+            <AlertTriangle className="h-3 w-3" />
+            <span>No slots</span>
+          </div>
+        ) : (
+          <span className="text-sm font-medium">{shift.slotSummary.totalHeadcount}</span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        <SkillsBadge skillIds={[]} talents={talents} />
+      </td>
+      <td className="px-4 py-3">
+        {isPlanner && (
+          <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={onEditStart}>
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:text-destructive"
+              onClick={() => onDelete(shift.id)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function ShiftList({
+  shifts,
+  isLoading,
+  isPlanner = false,
+  onEdit,
+  onDelete,
+}: ShiftListProps) {
+  const { data: talents = [] } = api.profile.listTalents.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const [editingShiftId, setEditingShiftId] = React.useState<string | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const handleEditStart = (shiftId: string) => {
+    setEditingShiftId(shiftId);
+  };
+
+  const handleEditSave = async (shiftId: string, data: { location: string; task: string }) => {
+    setIsSaving(true);
+    try {
+      // In a real implementation, this would call the API
+      // For now, we just call the onEdit callback if provided
+      const shift = shifts.find((s) => s.id === shiftId);
+      if (shift && onEdit) {
+        onEdit({
+          ...shift,
+          ...data,
+          skillIds: [],
+          tools: [],
+        });
+      }
+      setEditingShiftId(null);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleEditCancel = () => {
+    setEditingShiftId(null);
+  };
+
+  const handleDelete = (shiftId: string) => {
+    if (onDelete) {
+      onDelete(shiftId);
+    }
+  };
+
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (shifts.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="rounded-2xl border border-border bg-white shadow-sm">
+      <div className="overflow-x-auto" tabIndex={0} role="region" aria-label="Shift list">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Location
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Task
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Time
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Headcount
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Skills
+              </th>
+              {isPlanner && (
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Actions
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {shifts.map((shift) => (
+              <ShiftRow
+                key={shift.id}
+                shift={shift}
+                talents={talents}
+                isEditing={editingShiftId === shift.id}
+                isPlanner={isPlanner}
+                onEditStart={() => handleEditStart(shift.id)}
+                onEditSave={handleEditSave}
+                onEditCancel={handleEditCancel}
+                onDelete={handleDelete}
+                isSaving={isSaving}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shifts/shift-manager.stories.tsx
+++ b/src/components/shifts/shift-manager.stories.tsx
@@ -126,6 +126,7 @@ const mockUser = {
   id: "user-1",
   name: "Max Mustermann",
   email: "max@example.com",
+  isHeadOf: false,
   image: "https://i.pravatar.cc/150?u=shift-manager",
 };
 

--- a/src/components/shifts/shift-manager.stories.tsx
+++ b/src/components/shifts/shift-manager.stories.tsx
@@ -1,19 +1,22 @@
 /**
- * Stories for the Shifts page.
+ * Stories for the ShiftManager component.
  *
  * Uses MSW to mock tRPC endpoints so the component renders with realistic data.
- * Demonstrates different user states and view modes.
+ * Demonstrates loading state, error state, planner vs regular user, list vs calendar view.
  */
 
-import { ShiftManager } from "@/components/shifts/shift-manager";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { trpcQuery, trpcQueryError } from "../../../../.storybook/utils/trpc-helpers";
+import { trpcQuery, trpcMutation } from "../../../.storybook/utils/trpc-helpers";
+import { ShiftManager } from "./shift-manager";
 
 const meta = {
-  title: "Pages/Shifts",
+  title: "Shifts/ShiftManager",
   component: ShiftManager,
   parameters: {
-    layout: "fullscreen",
+    layout: "padded",
+    nextjs: {
+      appDirectory: true,
+    },
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof ShiftManager>;
@@ -186,13 +189,9 @@ const mockCalendarSlots = [
 ];
 
 /* ──────────────────────────────────────────────────────────────────────────
- * Stories
+ * Stories - Regular User (can view, cannot create)
  * ────────────────────────────────────────────────────────────────────────── */
 
-/**
- * Regular user viewing the shifts list.
- * No "Create" button visible since they're not a planner.
- */
 export const ListViewRegularUser: Story = {
   parameters: {
     msw: {
@@ -212,32 +211,6 @@ export const ListViewRegularUser: Story = {
   },
 };
 
-/**
- * Planner user (chair division) viewing the shifts list.
- * "Create" button is visible in the header.
- */
-export const ListViewPlanner: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        trpcQuery("profile", "getMy", () => ({
-          user: mockUser,
-          profile: mockPlannerProfile,
-        })),
-        trpcQuery("profile", "listTalents", () => mockTalents),
-        trpcQuery("shift", "list", () => ({
-          items: mockShifts,
-          total: mockShifts.length,
-          nextCursor: null,
-        })),
-      ],
-    },
-  },
-};
-
-/**
- * Empty state - no shifts available.
- */
 export const ListViewEmpty: Story = {
   parameters: {
     msw: {
@@ -257,9 +230,6 @@ export const ListViewEmpty: Story = {
   },
 };
 
-/**
- * Loading state - while fetching data.
- */
 export const ListViewLoading: Story = {
   parameters: {
     msw: {
@@ -271,14 +241,16 @@ export const ListViewLoading: Story = {
             profile: mockRegularProfile,
           };
         }),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
       ],
     },
   },
 };
 
-/**
- * Error state - when API call fails.
- */
 export const ListViewError: Story = {
   parameters: {
     msw: {
@@ -287,17 +259,15 @@ export const ListViewError: Story = {
           user: mockUser,
           profile: mockRegularProfile,
         })),
-        trpcQuery("profile", "listTalents", () => mockTalents),
-        trpcQueryError("shift", "list", "Failed to load shifts"),
+        trpcQuery("shift", "list", () => {
+          throw new Error("Failed to fetch shifts: Database connection timeout");
+        }),
       ],
     },
   },
 };
 
-/**
- * Calendar view - showing shifts by time slots.
- */
-export const CalendarView: Story = {
+export const CalendarViewRegularUser: Story = {
   parameters: {
     msw: {
       handlers: [
@@ -305,23 +275,10 @@ export const CalendarView: Story = {
           user: mockUser,
           profile: mockRegularProfile,
         })),
-        trpcQuery("profile", "listTalents", () => mockTalents),
-        trpcQuery("shift", "calendar", () => mockCalendarSlots),
-      ],
-    },
-  },
-};
-
-/**
- * Calendar view - planner user with create button.
- */
-export const CalendarViewPlanner: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        trpcQuery("profile", "getMy", () => ({
-          user: mockUser,
-          profile: mockPlannerProfile,
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
         })),
         trpcQuery("profile", "listTalents", () => mockTalents),
         trpcQuery("shift", "calendar", () => mockCalendarSlots),
@@ -330,9 +287,6 @@ export const CalendarViewPlanner: Story = {
   },
 };
 
-/**
- * Calendar view - empty day.
- */
 export const CalendarViewEmpty: Story = {
   parameters: {
     msw: {
@@ -341,8 +295,133 @@ export const CalendarViewEmpty: Story = {
           user: mockUser,
           profile: mockRegularProfile,
         })),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
         trpcQuery("profile", "listTalents", () => mockTalents),
         trpcQuery("shift", "calendar", () => []),
+      ],
+    },
+  },
+};
+
+export const CalendarViewLoading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockRegularProfile,
+        })),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "calendar", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100000));
+          return mockCalendarSlots;
+        }),
+      ],
+    },
+  },
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Stories - Planner User (can view AND create)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const ListViewPlanner: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockPlannerProfile,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "new-shift-id" })),
+      ],
+    },
+  },
+};
+
+export const CalendarViewPlanner: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockPlannerProfile,
+        })),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "calendar", () => mockCalendarSlots),
+        trpcMutation("shift", "create", () => ({ ok: true, id: "new-shift-id" })),
+      ],
+    },
+  },
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Stories - User Without Profile
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const NoProfile: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: null,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: mockShifts,
+          total: mockShifts.length,
+          nextCursor: null,
+        })),
+      ],
+    },
+  },
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Stories - Many Shifts (scroll testing)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const ManyShifts: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcQuery("profile", "getMy", () => ({
+          user: mockUser,
+          profile: mockRegularProfile,
+        })),
+        trpcQuery("profile", "listTalents", () => mockTalents),
+        trpcQuery("shift", "list", () => ({
+          items: Array.from({ length: 20 }, (_, i) => ({
+            ...mockShifts[i % mockShifts.length],
+            id: `shift-${i + 1}`,
+            location: `${mockShifts[i % mockShifts.length].location} ${i + 1}`,
+            startTime: new Date(`2026-04-0${(i % 9) + 1}T08:00:00`),
+            endTime: new Date(`2026-04-0${(i % 9) + 1}T12:00:00`),
+          })),
+          total: 20,
+          nextCursor: null,
+        })),
       ],
     },
   },

--- a/src/components/shifts/shift-manager.tsx
+++ b/src/components/shifts/shift-manager.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { api } from "@/server/api/client";
 import {
-  AlertCircle,
   AlertTriangle,
   Calendar,
   ChevronLeft,

--- a/src/components/shifts/shift-manager.tsx
+++ b/src/components/shifts/shift-manager.tsx
@@ -428,7 +428,12 @@ export function ShiftManager() {
           </div>
           {/* Create Button - Only for planners */}
           {isPlanner && (
-            <Button onClick={() => setIsCreateModalOpen(true)} size="sm" className="gap-1.5">
+            <Button
+              onClick={() => setIsCreateModalOpen(true)}
+              size="sm"
+              className="gap-1.5"
+              aria-label="Create shift"
+            >
               <Plus className="h-4 w-4" />
               <span className="hidden sm:inline">Create</span>
             </Button>

--- a/src/components/shifts/shift-manager.tsx
+++ b/src/components/shifts/shift-manager.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+import { ErrorBanner } from "@/components/alerting/error-banner";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { api } from "@/server/api/client";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  MapPin,
+  Plus,
+  Users,
+} from "lucide-react";
+import * as React from "react";
+import { ShiftForm } from "./shift-form";
+import { CsvExportButton } from "./csv-export-button";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Types
+ * ────────────────────────────────────────────────────────────────────────── */
+
+type ViewMode = "list" | "calendar";
+
+interface ShiftListItem {
+  id: string;
+  location: string;
+  task: string;
+  description: string | null;
+  notionLink: string | null;
+  startTime: Date;
+  endTime: Date;
+  createdBy: string;
+  createdAt: Date;
+  slotSummary: {
+    totalHeadcount: number;
+  };
+}
+
+interface CalendarSlot {
+  slotTime: Date;
+  totalHeadcount: number;
+  shifts: {
+    shiftId: string;
+    location: string;
+    task: string;
+    description: string | null;
+    notionLink: string | null;
+    startTime: Date;
+    endTime: Date;
+    headcount: number;
+  }[];
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function formatTime(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+function formatDateTimeRange(start: Date, end: Date): string {
+  return `${formatTime(start)} - ${formatTime(end)}`;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sub-Components
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function LoadingState() {
+  return (
+    <div className="grid gap-4">
+      {[1, 2, 3].map((i) => (
+        <Card key={i} className="p-4">
+          <div className="flex animate-pulse flex-col gap-3">
+            <div className="h-5 w-3/4 rounded bg-muted" />
+            <div className="h-4 w-1/2 rounded bg-muted" />
+            <div className="h-4 w-2/3 rounded bg-muted" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ message = "No shifts found" }: { message?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-muted/30 py-12 text-center">
+      <Calendar className="mb-3 h-10 w-10 text-muted-foreground/50" />
+      <p className="text-sm font-medium text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+function ShiftCard({ shift }: { shift: ShiftListItem }) {
+  return (
+    <Card className="overflow-hidden border-border bg-white shadow-sm transition-shadow hover:shadow-md">
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate font-semibold text-foreground">{shift.task}</h3>
+            <div className="mt-2 flex flex-col gap-1.5 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <MapPin className="h-4 w-4 shrink-0" />
+                <span className="truncate">{shift.location}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 shrink-0" />
+                <span>{formatDateTimeRange(shift.startTime, shift.endTime)}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Calendar className="h-4 w-4 shrink-0" />
+                <span>{formatDate(shift.startTime)}</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-col items-end gap-1">
+            {shift.slotSummary.totalHeadcount === 0 ? (
+              <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-700">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                <span>No slots</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                <Users className="h-3.5 w-3.5" />
+                <span>{shift.slotSummary.totalHeadcount}</span>
+              </div>
+            )}
+          </div>
+        </div>
+        {shift.description && (
+          <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{shift.description}</p>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function CalendarView({
+  slots,
+  selectedDate,
+  onDateChange,
+}: {
+  slots: CalendarSlot[];
+  selectedDate: Date;
+  onDateChange: (date: Date) => void;
+}) {
+  const navigateDay = (direction: "prev" | "next") => {
+    const newDate = new Date(selectedDate);
+    newDate.setDate(newDate.getDate() + (direction === "next" ? 1 : -1));
+    onDateChange(newDate);
+  };
+
+  // Group slots by hour for display
+  const slotsByHour = React.useMemo(() => {
+    const grouped = new Map<number, CalendarSlot[]>();
+    for (const slot of slots) {
+      const hour = slot.slotTime.getHours();
+      const existing = grouped.get(hour) ?? [];
+      existing.push(slot);
+      grouped.set(hour, existing);
+    }
+    return new Map([...grouped.entries()].sort((a, b) => a[0] - b[0]));
+  }, [slots]);
+
+  return (
+    <div className="grid gap-4">
+      {/* Date Navigation */}
+      <div className="flex items-center justify-between rounded-xl border border-border bg-white p-3 shadow-sm">
+        <Button variant="ghost" size="icon" onClick={() => navigateDay("prev")} className="h-9 w-9">
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <div className="text-center">
+          <div className="font-semibold text-foreground">
+            {selectedDate.toLocaleDateString("en-US", {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            })}
+          </div>
+          <div className="text-xs text-muted-foreground">2026</div>
+        </div>
+        <Button variant="ghost" size="icon" onClick={() => navigateDay("next")} className="h-9 w-9">
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      </div>
+
+      {/* Calendar Slots */}
+      {slots.length === 0 ? (
+        <EmptyState message="No shifts scheduled for this day" />
+      ) : (
+        <div className="grid gap-3">
+          {Array.from(slotsByHour.entries()).map(([hour, hourSlots]) => (
+            <div key={hour} className="grid gap-2">
+              <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                <Clock className="h-3.5 w-3.5" />
+                <span>{`${hour.toString().padStart(2, "0")}:00`}</span>
+              </div>
+              <div className="grid gap-2">
+                {hourSlots.map((slot) => (
+                  <Card key={slot.slotTime.toISOString()} className="overflow-hidden border-border">
+                    <div className="flex items-center justify-between border-b border-border bg-muted/30 px-3 py-2">
+                      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                        <Clock className="h-3.5 w-3.5" />
+                        <span>{formatTime(slot.slotTime)}</span>
+                      </div>
+                      <div className="flex items-center gap-1.5 text-xs font-medium text-primary">
+                        <Users className="h-3.5 w-3.5" />
+                        <span>{slot.totalHeadcount} volunteers</span>
+                      </div>
+                    </div>
+                    <div className="p-3">
+                      {slot.shifts.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No shifts at this time</p>
+                      ) : (
+                        <div className="grid gap-2">
+                          {slot.shifts.map((shift) => (
+                            <div
+                              key={shift.shiftId}
+                              className="flex items-start justify-between gap-2 rounded-lg border border-border bg-white p-2.5"
+                            >
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-medium text-foreground">
+                                  {shift.task}
+                                </p>
+                                <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                                  <MapPin className="h-3 w-3" />
+                                  <span className="truncate">{shift.location}</span>
+                                </p>
+                              </div>
+                              <div className="flex shrink-0 items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                                <Users className="h-3 w-3" />
+                                <span>{shift.headcount}</span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CreateShiftModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-background p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-foreground">Create New Shift</h2>
+          <Button variant="ghost" size="icon" onClick={onClose} className="h-9 w-9">
+            <span className="sr-only">Close</span>
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </Button>
+        </div>
+        <ShiftForm onSuccess={onClose} />
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Component
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export function ShiftManager() {
+  const [viewMode, setViewMode] = React.useState<ViewMode>("list");
+  const [isCreateModalOpen, setIsCreateModalOpen] = React.useState(false);
+  const [selectedDate, setSelectedDate] = React.useState(() => {
+    // Default to April 9, 2026 (Q-Summit date)
+    const date = new Date(2026, 3, 9); // Month is 0-indexed
+    return date;
+  });
+
+  // Check if user has planner role
+  const { data: profileData, isLoading: isProfileLoading } = api.profile.getMy.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const isPlanner = profileData?.profile?.division === "chair";
+
+  // Fetch shifts list
+  const {
+    data: listData,
+    isLoading: isListLoading,
+    error: listError,
+    refetch: refetchList,
+  } = api.shift.list.useQuery(
+    {
+      limit: 50,
+      sortField: "startTime",
+      sortDirection: "asc",
+    },
+    {
+      refetchOnWindowFocus: false,
+      enabled: viewMode === "list",
+    },
+  );
+
+  // Fetch calendar data
+  const {
+    data: calendarData,
+    isLoading: isCalendarLoading,
+    error: calendarError,
+    refetch: refetchCalendar,
+  } = api.shift.calendar.useQuery(
+    {
+      date: selectedDate,
+    },
+    {
+      refetchOnWindowFocus: false,
+      enabled: viewMode === "calendar",
+    },
+  );
+
+  const isLoading = isListLoading || isCalendarLoading || isProfileLoading;
+  const error = listError ?? calendarError;
+
+  const handleDateChange = (date: Date) => {
+    setSelectedDate(date);
+  };
+
+  const handleRefresh = () => {
+    if (viewMode === "list") {
+      void refetchList();
+    } else {
+      void refetchCalendar();
+    }
+  };
+
+  return (
+    <div className="grid gap-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Shifts</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manage volunteer shifts for Q-Summit 2026
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* View Toggle */}
+          <div className="flex rounded-lg border border-border bg-muted p-1">
+            <Button
+              variant={viewMode === "list" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("list")}
+              className="text-xs font-medium"
+            >
+              List
+            </Button>
+            <Button
+              variant={viewMode === "calendar" ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("calendar")}
+              className="text-xs font-medium"
+            >
+              Calendar
+            </Button>
+          </div>
+          {/* Create Button - Only for planners */}
+          {isPlanner && (
+            <Button onClick={() => setIsCreateModalOpen(true)} size="sm" className="gap-1.5">
+              <Plus className="h-4 w-4" />
+              <span className="hidden sm:inline">Create</span>
+            </Button>
+          )}
+          {/* Export Button - Only for planners and in list view */}
+          {isPlanner && viewMode === "list" && <CsvExportButton />}
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <ErrorBanner
+          title="Failed to load shifts"
+          message={error.message}
+          className="animate-in fade-in slide-in-from-top-2"
+        />
+      )}
+
+      {/* Content */}
+      {isLoading ? (
+        <LoadingState />
+      ) : (
+        <>
+          {viewMode === "list" && (
+            <>
+              <h2 className="sr-only">Shift list</h2>
+              {listData?.items && listData.items.length > 0 ? (
+                <div className="grid gap-3">
+                  {listData.items.map((shift) => (
+                    <ShiftCard key={shift.id} shift={shift as ShiftListItem} />
+                  ))}
+                </div>
+              ) : (
+                <EmptyState />
+              )}
+            </>
+          )}
+
+          {viewMode === "calendar" && (
+            <CalendarView
+              slots={(calendarData ?? []) as CalendarSlot[]}
+              selectedDate={selectedDate}
+              onDateChange={handleDateChange}
+            />
+          )}
+        </>
+      )}
+
+      {/* Create Modal */}
+      <CreateShiftModal
+        isOpen={isCreateModalOpen}
+        onClose={() => {
+          setIsCreateModalOpen(false);
+          handleRefresh();
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/shifts/shift-manager.tsx
+++ b/src/components/shifts/shift-manager.tsx
@@ -54,6 +54,20 @@ interface CalendarSlot {
   }[];
 }
 
+/** Q-Summit 2026 dates — only these are valid for shift.calendar API */
+const QSUMMIT_DATES: readonly Date[] = [
+  new Date(2026, 3, 9), // April 9, 2026 (month is 0-indexed)
+  new Date(2026, 3, 10), // April 10, 2026
+];
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
 /* ──────────────────────────────────────────────────────────────────────────
  * Helpers
  * ────────────────────────────────────────────────────────────────────────── */
@@ -133,7 +147,7 @@ function ShiftCard({ shift }: { shift: ShiftListItem }) {
             {shift.slotSummary.totalHeadcount === 0 ? (
               <div className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-700">
                 <AlertTriangle className="h-3.5 w-3.5" />
-                <span>No slots</span>
+                <span>Unstaffed</span>
               </div>
             ) : (
               <div className="flex items-center gap-1.5 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
@@ -160,10 +174,19 @@ function CalendarView({
   selectedDate: Date;
   onDateChange: (date: Date) => void;
 }) {
+  const currentIndex = (() => {
+    const i = QSUMMIT_DATES.findIndex((d) => isSameCalendarDay(d, selectedDate));
+    return i >= 0 ? i : 0;
+  })();
+  const canGoPrev = currentIndex > 0;
+  const canGoNext = currentIndex < QSUMMIT_DATES.length - 1;
+
   const navigateDay = (direction: "prev" | "next") => {
-    const newDate = new Date(selectedDate);
-    newDate.setDate(newDate.getDate() + (direction === "next" ? 1 : -1));
-    onDateChange(newDate);
+    const newIndex =
+      direction === "next"
+        ? Math.min(currentIndex + 1, QSUMMIT_DATES.length - 1)
+        : Math.max(currentIndex - 1, 0);
+    onDateChange(QSUMMIT_DATES[newIndex]);
   };
 
   // Group slots by hour for display
@@ -182,7 +205,14 @@ function CalendarView({
     <div className="grid gap-4">
       {/* Date Navigation */}
       <div className="flex items-center justify-between rounded-xl border border-border bg-white p-3 shadow-sm">
-        <Button variant="ghost" size="icon" onClick={() => navigateDay("prev")} className="h-9 w-9">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigateDay("prev")}
+          disabled={!canGoPrev}
+          className="h-9 w-9"
+          aria-label="Previous day"
+        >
           <ChevronLeft className="h-5 w-5" />
         </Button>
         <div className="text-center">
@@ -193,9 +223,16 @@ function CalendarView({
               day: "numeric",
             })}
           </div>
-          <div className="text-xs text-muted-foreground">2026</div>
+          <div className="text-xs text-muted-foreground">{selectedDate.getFullYear()}</div>
         </div>
-        <Button variant="ghost" size="icon" onClick={() => navigateDay("next")} className="h-9 w-9">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigateDay("next")}
+          disabled={!canGoNext}
+          className="h-9 w-9"
+          aria-label="Next day"
+        >
           <ChevronRight className="h-5 w-5" />
         </Button>
       </div>
@@ -307,7 +344,8 @@ export function ShiftManager() {
     refetchOnWindowFocus: false,
   });
 
-  const isPlanner = profileData?.profile?.division === "chair";
+  const isPlanner =
+    (profileData?.profile?.division === "chair" || profileData?.user?.isHeadOf === true) ?? false;
 
   // Fetch shifts list
   const {

--- a/src/domain/qsum/shifts/constants.ts
+++ b/src/domain/qsum/shifts/constants.ts
@@ -1,0 +1,22 @@
+import type { LabeledValue, Tool } from "./types";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Option Lists
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const TOOL_OPTIONS: readonly LabeledValue<Tool>[] = [
+  { value: "none", label: "None" },
+  { value: "car", label: "Car" },
+  { value: "van", label: "Van" },
+  { value: "equipment", label: "Equipment" },
+] as const;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Defaults
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Default shift duration in milliseconds (2 hours) */
+export const DEFAULT_SHIFT_DURATION_MS = 2 * 60 * 60 * 1000;
+
+/** Slot duration in milliseconds (30 minutes) */
+export const SLOT_DURATION_MS = 30 * 60 * 1000;

--- a/src/domain/qsum/shifts/constants.ts
+++ b/src/domain/qsum/shifts/constants.ts
@@ -5,7 +5,6 @@ import type { LabeledValue, Tool } from "./types";
  * ────────────────────────────────────────────────────────────────────────── */
 
 export const TOOL_OPTIONS: readonly LabeledValue<Tool>[] = [
-  { value: "none", label: "None" },
   { value: "car", label: "Car" },
   { value: "van", label: "Van" },
   { value: "equipment", label: "Equipment" },

--- a/src/domain/qsum/shifts/index.ts
+++ b/src/domain/qsum/shifts/index.ts
@@ -1,0 +1,4 @@
+// Export everything from the sub-modules
+export * from "./constants";
+export * from "./types";
+export * from "./validation";

--- a/src/domain/qsum/shifts/types.ts
+++ b/src/domain/qsum/shifts/types.ts
@@ -2,7 +2,7 @@
  * Explicit Domain Primitives
  * ────────────────────────────────────────────────────────────────────────── */
 
-export type Tool = "car" | "van" | "equipment" | "none";
+export type Tool = "car" | "van" | "equipment";
 
 /* ──────────────────────────────────────────────────────────────────────────
  * UI & Helper Interfaces

--- a/src/domain/qsum/shifts/types.ts
+++ b/src/domain/qsum/shifts/types.ts
@@ -1,0 +1,49 @@
+/* ──────────────────────────────────────────────────────────────────────────
+ * Explicit Domain Primitives
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export type Tool = "car" | "van" | "equipment" | "none";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * UI & Helper Interfaces
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export interface LabeledValue<T extends string> {
+  value: T;
+  label: string;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Domain Entities
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export interface Shift {
+  id: string;
+  location: string;
+  task: string;
+  description?: string | null;
+  notionLink?: string | null;
+  startTime: Date;
+  endTime: Date;
+  createdBy: string;
+  createdAt: Date;
+}
+
+export interface ShiftSlot {
+  id: string;
+  shiftId: string;
+  slotTime: Date;
+  headcount: number;
+}
+
+export interface ShiftSkill {
+  id: string;
+  shiftId: string;
+  talentId: string;
+}
+
+export interface ShiftTool {
+  id: string;
+  shiftId: string;
+  tool: Tool;
+}

--- a/src/domain/qsum/shifts/validation.ts
+++ b/src/domain/qsum/shifts/validation.ts
@@ -23,25 +23,34 @@ export type SlotInput = z.infer<typeof SlotInputSchema>;
  * Main Validation Schemas
  * ────────────────────────────────────────────────────────────────────────── */
 
-const notionUrlSchema = z
-  .string()
-  .trim()
-  .url()
-  .refine(
-    (value) => {
-      try {
-        const url = new URL(value);
-        const host = url.hostname.toLowerCase();
-        return host === "notion.so" || host === "www.notion.so" || host.endsWith(".notion.so");
-      } catch {
-        return false;
-      }
-    },
-    {
-      message: "Notion URL must be on notion.so",
-    },
-  )
-  .nullable();
+const notionUrlSchema = z.preprocess(
+  (val) => {
+    // Allow blank strings to pass through as null before URL validation
+    if (val === null || val === undefined || (typeof val === "string" && val.trim() === "")) {
+      return null;
+    }
+    return val;
+  },
+  z
+    .string()
+    .trim()
+    .url()
+    .refine(
+      (value) => {
+        try {
+          const url = new URL(value);
+          const host = url.hostname.toLowerCase();
+          return host === "notion.so" || host === "www.notion.so" || host.endsWith(".notion.so");
+        } catch {
+          return false;
+        }
+      },
+      {
+        message: "Notion URL must be on notion.so",
+      },
+    )
+    .nullable(),
+);
 
 export const ShiftCreateSchema = z
   .object({

--- a/src/domain/qsum/shifts/validation.ts
+++ b/src/domain/qsum/shifts/validation.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { TOOL_OPTIONS } from "./constants";
+import type { Tool } from "./types";
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Zod Primitives (Derived from Constants)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const toolValues = TOOL_OPTIONS.map((o) => o.value) as [Tool, ...Tool[]];
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Slot Input Schema
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const SlotInputSchema = z.object({
+  slotTime: z.coerce.date(),
+  headcount: z.number().int().min(0).max(100),
+});
+
+export type SlotInput = z.infer<typeof SlotInputSchema>;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Main Validation Schemas
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const notionUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(value);
+        const host = url.hostname.toLowerCase();
+        return host === "notion.so" || host === "www.notion.so" || host.endsWith(".notion.so");
+      } catch {
+        return false;
+      }
+    },
+    {
+      message: "Notion URL must be on notion.so",
+    },
+  )
+  .nullable();
+
+export const ShiftCreateSchema = z
+  .object({
+    location: z.string().trim().min(1).max(200),
+    task: z.string().trim().min(1).max(200),
+    description: z.string().trim().max(2000).nullable(),
+    notionLink: notionUrlSchema,
+    startTime: z.coerce.date(),
+    endTime: z.coerce.date(),
+    skillIds: z.array(z.string().min(1)).default([]),
+    tools: z.array(z.enum(toolValues)).default([]),
+    slots: z.array(SlotInputSchema).optional(),
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    message: "End time must be after start time",
+    path: ["endTime"],
+  });
+
+export type ShiftCreateInput = z.infer<typeof ShiftCreateSchema>;
+
+export const ShiftUpdateSchema = z
+  .object({
+    id: z.string().min(1),
+    location: z.string().trim().min(1).max(200),
+    task: z.string().trim().min(1).max(200),
+    description: z.string().trim().max(2000).nullable(),
+    notionLink: notionUrlSchema,
+    startTime: z.coerce.date(),
+    endTime: z.coerce.date(),
+    skillIds: z.array(z.string().min(1)).default([]),
+    tools: z.array(z.enum(toolValues)).default([]),
+    slots: z.array(SlotInputSchema).optional(),
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    message: "End time must be after start time",
+    path: ["endTime"],
+  });
+
+export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Normalizers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Helper to clean up data before sending to DB.
+ * Ensures consistent null states for optional fields.
+ */
+export function normalizeShiftCreateInput(input: ShiftCreateInput, createdBy: string) {
+  return {
+    location: input.location.trim(),
+    task: input.task.trim(),
+    description: input.description?.trim() ?? null,
+    notionLink: input.notionLink?.trim() ?? null,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    createdBy,
+    skillIds: input.skillIds,
+    tools: input.tools,
+    slots: input.slots,
+  } as const;
+}
+
+export function normalizeShiftUpdateInput(input: ShiftUpdateInput) {
+  return {
+    id: input.id,
+    location: input.location.trim(),
+    task: input.task.trim(),
+    description: input.description?.trim() ?? null,
+    notionLink: input.notionLink?.trim() ?? null,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    skillIds: input.skillIds,
+    tools: input.tools,
+    slots: input.slots,
+  } as const;
+}

--- a/src/domain/qsum/shifts/validation.ts
+++ b/src/domain/qsum/shifts/validation.ts
@@ -58,6 +58,14 @@ export const ShiftCreateSchema = z
   .refine((data) => data.endTime > data.startTime, {
     message: "End time must be after start time",
     path: ["endTime"],
+  })
+  .refine((data) => new Set(data.skillIds).size === data.skillIds.length, {
+    message: "skillIds must be unique",
+    path: ["skillIds"],
+  })
+  .refine((data) => new Set(data.tools).size === data.tools.length, {
+    message: "tools must be unique",
+    path: ["tools"],
   });
 
 export type ShiftCreateInput = z.infer<typeof ShiftCreateSchema>;
@@ -78,6 +86,14 @@ export const ShiftUpdateSchema = z
   .refine((data) => data.endTime > data.startTime, {
     message: "End time must be after start time",
     path: ["endTime"],
+  })
+  .refine((data) => new Set(data.skillIds).size === data.skillIds.length, {
+    message: "skillIds must be unique",
+    path: ["skillIds"],
+  })
+  .refine((data) => new Set(data.tools).size === data.tools.length, {
+    message: "tools must be unique",
+    path: ["tools"],
   });
 
 export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;
@@ -87,20 +103,25 @@ export type ShiftUpdateInput = z.infer<typeof ShiftUpdateSchema>;
  * ────────────────────────────────────────────────────────────────────────── */
 
 /**
- * Helper to clean up data before sending to DB.
- * Ensures consistent null states for optional fields.
+ * Treats blank (empty or whitespace-only) strings as null for optional fields.
+ * Used so optional description/notionLink are stored as null when absent.
  */
+function blankToNull(s: string | null | undefined): string | null {
+  const t = s?.trim();
+  return t === undefined || t === "" ? null : t;
+}
+
 export function normalizeShiftCreateInput(input: ShiftCreateInput, createdBy: string) {
   return {
     location: input.location.trim(),
     task: input.task.trim(),
-    description: input.description?.trim() ?? null,
-    notionLink: input.notionLink?.trim() ?? null,
+    description: blankToNull(input.description),
+    notionLink: blankToNull(input.notionLink),
     startTime: input.startTime,
     endTime: input.endTime,
     createdBy,
-    skillIds: input.skillIds,
-    tools: input.tools,
+    skillIds: [...new Set(input.skillIds)],
+    tools: [...new Set(input.tools)],
     slots: input.slots,
   } as const;
 }
@@ -110,12 +131,12 @@ export function normalizeShiftUpdateInput(input: ShiftUpdateInput) {
     id: input.id,
     location: input.location.trim(),
     task: input.task.trim(),
-    description: input.description?.trim() ?? null,
-    notionLink: input.notionLink?.trim() ?? null,
+    description: blankToNull(input.description),
+    notionLink: blankToNull(input.notionLink),
     startTime: input.startTime,
     endTime: input.endTime,
-    skillIds: input.skillIds,
-    tools: input.tools,
+    skillIds: [...new Set(input.skillIds)],
+    tools: [...new Set(input.tools)],
     slots: input.slots,
   } as const;
 }

--- a/src/lib/use-is-planner.ts
+++ b/src/lib/use-is-planner.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { api } from "@/server/api/client";
+
+/**
+ * Hook to check if the current user is a planner (Chair/Board member).
+ * Planners have division === "chair" in their profile.
+ */
+export function useIsPlanner(): { isPlanner: boolean; isLoading: boolean } {
+  const { data, isLoading } = api.profile.getMy.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const isPlanner = data?.profile?.division === "chair";
+
+  return { isPlanner, isLoading };
+}

--- a/src/lib/use-is-planner.ts
+++ b/src/lib/use-is-planner.ts
@@ -3,15 +3,15 @@
 import { api } from "@/server/api/client";
 
 /**
- * Hook to check if the current user is a planner (Chair/Board member).
- * Planners have division === "chair" in their profile.
+ * Hook to check if the current user is a planner (can access shift management).
+ * Uses isHeadOf access flag and division === "chair" so Chair, Board, and authorized heads are included.
  */
 export function useIsPlanner(): { isPlanner: boolean; isLoading: boolean } {
   const { data, isLoading } = api.profile.getMy.useQuery(undefined, {
     refetchOnWindowFocus: false,
   });
 
-  const isPlanner = data?.profile?.division === "chair";
+  const isPlanner = (data?.profile?.division === "chair" || data?.user?.isHeadOf === true) ?? false;
 
   return { isPlanner, isLoading };
 }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,10 +1,12 @@
 import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
-import { slackRouter } from "./routers/slack";
 import { profileRouter } from "./routers/profile";
+import { shiftRouter } from "./routers/shift";
+import { slackRouter } from "./routers/slack";
 
 export const appRouter = createTRPCRouter({
-  slack: slackRouter,
   profile: profileRouter,
+  shift: shiftRouter,
+  slack: slackRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -18,12 +18,17 @@ export const profileRouter = createTRPCRouter({
     const userId = ctx.session.user.id;
     const { name, image } = ctx.session.user;
 
-    const profile = await ctx.db.query.memberProfile.findFirst({
-      where: eq(memberProfile.userId, userId),
-    });
+    const [profile, userRow] = await Promise.all([
+      ctx.db.query.memberProfile.findFirst({
+        where: eq(memberProfile.userId, userId),
+      }),
+      ctx.db.select({ isHeadOf: user.isHeadOf }).from(user).where(eq(user.id, userId)).limit(1),
+    ]);
+
+    const isHeadOf = userRow[0]?.isHeadOf ?? false;
 
     if (!profile) {
-      return { user: { name, image }, profile: null };
+      return { user: { name, image, isHeadOf }, profile: null };
     }
 
     const talentRows: { talentId: string }[] = await ctx.db
@@ -32,7 +37,7 @@ export const profileRouter = createTRPCRouter({
       .where(eq(userTalent.userId, userId));
 
     return {
-      user: { name, image },
+      user: { name, image, isHeadOf },
       profile: {
         ...profile,
         talentIds: talentRows.map((row) => row.talentId),

--- a/src/server/api/routers/shift.ts
+++ b/src/server/api/routers/shift.ts
@@ -353,10 +353,10 @@ export const shiftRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const dayStart = new Date(input.date);
-      dayStart.setHours(0, 0, 0, 0);
+      dayStart.setUTCHours(0, 0, 0, 0);
 
       const dayEnd = new Date(dayStart);
-      dayEnd.setDate(dayEnd.getDate() + 1);
+      dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
 
       const slotTimeFilter = and(
         gte(shiftSlots.slotTime, dayStart),
@@ -435,11 +435,12 @@ export const shiftRouter = createTRPCRouter({
     });
 
     if (allShifts.length === 0) {
-      // UTF-8 BOM + header only
       return {
-        csv: "\uFEFFshift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link",
+        csv: "shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link",
       };
     }
+
+    const shiftById = new Map(allShifts.map((s) => [s.id, s]));
 
     const shiftIds = allShifts.map((s) => s.id);
 
@@ -484,7 +485,7 @@ export const shiftRouter = createTRPCRouter({
     const rows: string[] = [header];
 
     for (const slot of allSlots) {
-      const shift = allShifts.find((s) => s.id === slot.shiftId);
+      const shift = shiftById.get(slot.shiftId);
       if (!shift) continue;
 
       const skills = (skillsByShift.get(slot.shiftId) ?? []).join(",");
@@ -522,8 +523,7 @@ export const shiftRouter = createTRPCRouter({
       rows.push(row);
     }
 
-    // UTF-8 BOM for German Excel compatibility
-    const csv = "\uFEFF" + rows.join("\n");
+    const csv = rows.join("\n");
     return { csv };
   }),
 });

--- a/src/server/api/routers/shift.ts
+++ b/src/server/api/routers/shift.ts
@@ -1,0 +1,529 @@
+/**
+ * Shift router - handles shift planning CRUD and scheduling.
+ */
+import {
+  ShiftCreateSchema,
+  ShiftUpdateSchema,
+  normalizeShiftCreateInput,
+  normalizeShiftUpdateInput,
+  type SlotInput,
+} from "@/domain/qsum/shifts";
+import { createTRPCRouter, plannerProcedure, protectedProcedure } from "@/server/api/trpc";
+import { shiftSkills, shiftSlots, shiftTools, shifts } from "@/server/db/schema";
+import { TRPCError } from "@trpc/server";
+import { and, asc, count, desc, eq, gte, inArray, like, lt, lte, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const SLOT_INTERVAL_MS = 30 * 60 * 1000;
+
+function assertThirtyMinuteBoundary(date: Date, fieldName: string) {
+  if (date.getTime() % SLOT_INTERVAL_MS !== 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `${fieldName} must be on a 30-minute boundary`,
+    });
+  }
+}
+
+function buildShiftSlots(startTime: Date, endTime: Date, inputSlots?: SlotInput[]) {
+  assertThirtyMinuteBoundary(startTime, "startTime");
+  assertThirtyMinuteBoundary(endTime, "endTime");
+
+  if (inputSlots && inputSlots.length > 0) {
+    const seen = new Set<number>();
+
+    const normalizedSlots = inputSlots
+      .map((slot) => ({
+        slotTime: new Date(slot.slotTime),
+        headcount: slot.headcount,
+      }))
+      .sort((a, b) => a.slotTime.getTime() - b.slotTime.getTime());
+
+    for (const slot of normalizedSlots) {
+      assertThirtyMinuteBoundary(slot.slotTime, "slotTime");
+
+      const timestamp = slot.slotTime.getTime();
+      if (timestamp < startTime.getTime() || timestamp >= endTime.getTime()) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "slotTime must be within the shift time range",
+        });
+      }
+
+      if (seen.has(timestamp)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Duplicate slotTime values are not allowed",
+        });
+      }
+
+      seen.add(timestamp);
+    }
+
+    return normalizedSlots;
+  }
+
+  const slots: { slotTime: Date; headcount: number }[] = [];
+  for (let ts = startTime.getTime(); ts < endTime.getTime(); ts += SLOT_INTERVAL_MS) {
+    slots.push({ slotTime: new Date(ts), headcount: 0 });
+  }
+
+  return slots;
+}
+
+export const shiftRouter = createTRPCRouter({
+  create: plannerProcedure.input(ShiftCreateSchema).mutation(async ({ ctx, input }) => {
+    const normalizedInput = normalizeShiftCreateInput(input, ctx.session.user.id);
+    const shiftId = crypto.randomUUID();
+    const slots = buildShiftSlots(
+      normalizedInput.startTime,
+      normalizedInput.endTime,
+      normalizedInput.slots,
+    );
+
+    await ctx.db.transaction(async (tx) => {
+      await tx.insert(shifts).values({
+        id: shiftId,
+        location: normalizedInput.location,
+        task: normalizedInput.task,
+        description: normalizedInput.description,
+        notionLink: normalizedInput.notionLink,
+        startTime: normalizedInput.startTime,
+        endTime: normalizedInput.endTime,
+        createdBy: normalizedInput.createdBy,
+        createdAt: new Date(),
+      });
+
+      await tx.insert(shiftSlots).values(
+        slots.map((slot) => ({
+          id: crypto.randomUUID(),
+          shiftId,
+          slotTime: slot.slotTime,
+          headcount: slot.headcount,
+        })),
+      );
+
+      if (normalizedInput.skillIds.length > 0) {
+        await tx.insert(shiftSkills).values(
+          normalizedInput.skillIds.map((talentId) => ({
+            id: crypto.randomUUID(),
+            shiftId,
+            talentId,
+          })),
+        );
+      }
+
+      if (normalizedInput.tools.length > 0) {
+        await tx.insert(shiftTools).values(
+          normalizedInput.tools.map((tool) => ({
+            id: crypto.randomUUID(),
+            shiftId,
+            tool,
+          })),
+        );
+      }
+    });
+
+    return { ok: true, id: shiftId };
+  }),
+
+  getById: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const shift = await ctx.db.query.shifts.findFirst({
+        where: eq(shifts.id, input.id),
+      });
+
+      if (!shift) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Shift not found." });
+      }
+
+      const [slots, skills, tools] = await Promise.all([
+        ctx.db
+          .select({
+            id: shiftSlots.id,
+            slotTime: shiftSlots.slotTime,
+            headcount: shiftSlots.headcount,
+          })
+          .from(shiftSlots)
+          .where(eq(shiftSlots.shiftId, shift.id))
+          .orderBy(shiftSlots.slotTime),
+        ctx.db
+          .select({ talentId: shiftSkills.talentId })
+          .from(shiftSkills)
+          .where(eq(shiftSkills.shiftId, shift.id)),
+        ctx.db
+          .select({ tool: shiftTools.tool })
+          .from(shiftTools)
+          .where(eq(shiftTools.shiftId, shift.id)),
+      ]);
+
+      return {
+        ...shift,
+        skillIds: skills.map((skill) => skill.talentId),
+        tools: tools.map((tool) => tool.tool),
+        slots,
+      };
+    }),
+
+  update: plannerProcedure.input(ShiftUpdateSchema).mutation(async ({ ctx, input }) => {
+    const normalizedInput = normalizeShiftUpdateInput(input);
+    const slots = buildShiftSlots(
+      normalizedInput.startTime,
+      normalizedInput.endTime,
+      normalizedInput.slots,
+    );
+
+    const existingShift = await ctx.db.query.shifts.findFirst({
+      where: eq(shifts.id, normalizedInput.id),
+      columns: { id: true },
+    });
+
+    if (!existingShift) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Shift not found." });
+    }
+
+    await ctx.db.transaction(async (tx) => {
+      await tx
+        .update(shifts)
+        .set({
+          location: normalizedInput.location,
+          task: normalizedInput.task,
+          description: normalizedInput.description,
+          notionLink: normalizedInput.notionLink,
+          startTime: normalizedInput.startTime,
+          endTime: normalizedInput.endTime,
+        })
+        .where(eq(shifts.id, normalizedInput.id));
+
+      await tx.delete(shiftSlots).where(eq(shiftSlots.shiftId, normalizedInput.id));
+      await tx.delete(shiftSkills).where(eq(shiftSkills.shiftId, normalizedInput.id));
+      await tx.delete(shiftTools).where(eq(shiftTools.shiftId, normalizedInput.id));
+
+      await tx.insert(shiftSlots).values(
+        slots.map((slot) => ({
+          id: crypto.randomUUID(),
+          shiftId: normalizedInput.id,
+          slotTime: slot.slotTime,
+          headcount: slot.headcount,
+        })),
+      );
+
+      if (normalizedInput.skillIds.length > 0) {
+        await tx.insert(shiftSkills).values(
+          normalizedInput.skillIds.map((talentId) => ({
+            id: crypto.randomUUID(),
+            shiftId: normalizedInput.id,
+            talentId,
+          })),
+        );
+      }
+
+      if (normalizedInput.tools.length > 0) {
+        await tx.insert(shiftTools).values(
+          normalizedInput.tools.map((tool) => ({
+            id: crypto.randomUUID(),
+            shiftId: normalizedInput.id,
+            tool,
+          })),
+        );
+      }
+    });
+
+    return { ok: true };
+  }),
+
+  delete: plannerProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const existingShift = await ctx.db.query.shifts.findFirst({
+        where: eq(shifts.id, input.id),
+        columns: { id: true },
+      });
+
+      if (!existingShift) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Shift not found." });
+      }
+
+      await ctx.db.delete(shifts).where(eq(shifts.id, input.id));
+
+      return { ok: true };
+    }),
+
+  list: protectedProcedure
+    .input(
+      z.object({
+        cursor: z.number().int().nonnegative().default(0),
+        limit: z.number().int().min(1).max(50).default(20),
+        sortField: z.enum(["startTime", "location", "task", "createdAt"]).default("startTime"),
+        sortDirection: z.enum(["asc", "desc"]).default("asc"),
+        location: z.string().trim().max(200).optional(),
+        startDate: z.coerce.date().optional(),
+        endDate: z.coerce.date().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { cursor, limit, sortField, sortDirection, location, startDate, endDate } = input;
+
+      const conditions = [];
+      if (location) conditions.push(like(shifts.location, `%${location}%`));
+      if (startDate) conditions.push(gte(shifts.startTime, startDate));
+      if (endDate) conditions.push(lte(shifts.startTime, endDate));
+      const baseWhere = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const sortColumns = {
+        startTime: shifts.startTime,
+        location: shifts.location,
+        task: shifts.task,
+        createdAt: shifts.createdAt,
+      } as const;
+      const sortExpression =
+        sortDirection === "desc" ? desc(sortColumns[sortField]) : asc(sortColumns[sortField]);
+
+      const [totalResult, rows] = await Promise.all([
+        ctx.db.select({ value: count() }).from(shifts).where(baseWhere),
+        ctx.db
+          .select({
+            id: shifts.id,
+            location: shifts.location,
+            task: shifts.task,
+            description: shifts.description,
+            notionLink: shifts.notionLink,
+            startTime: shifts.startTime,
+            endTime: shifts.endTime,
+            createdBy: shifts.createdBy,
+            createdAt: shifts.createdAt,
+          })
+          .from(shifts)
+          .where(baseWhere)
+          .orderBy(sortExpression, asc(shifts.id))
+          .limit(limit)
+          .offset(cursor),
+      ]);
+
+      const shiftIds = rows.map((row) => row.id);
+      const totalHeadcountByShift = new Map<string, number>();
+
+      if (shiftIds.length > 0) {
+        const slotRows = await ctx.db
+          .select({
+            shiftId: shiftSlots.shiftId,
+            headcount: shiftSlots.headcount,
+          })
+          .from(shiftSlots)
+          .where(inArray(shiftSlots.shiftId, shiftIds));
+
+        for (const slot of slotRows) {
+          totalHeadcountByShift.set(
+            slot.shiftId,
+            (totalHeadcountByShift.get(slot.shiftId) ?? 0) + slot.headcount,
+          );
+        }
+      }
+
+      const total = totalResult[0]?.value ?? 0;
+
+      return {
+        items: rows.map((row) => ({
+          ...row,
+          slotSummary: {
+            totalHeadcount: totalHeadcountByShift.get(row.id) ?? 0,
+          },
+        })),
+        total,
+        nextCursor: cursor + limit < total ? cursor + limit : null,
+      };
+    }),
+
+  calendar: protectedProcedure
+    .input(
+      z.object({
+        date: z.coerce.date().refine((date) => {
+          const isLocalQSummitDate =
+            date.getFullYear() === 2026 &&
+            date.getMonth() === 3 &&
+            (date.getDate() === 9 || date.getDate() === 10);
+          const isUtcQSummitDate =
+            date.getUTCFullYear() === 2026 &&
+            date.getUTCMonth() === 3 &&
+            (date.getUTCDate() === 9 || date.getUTCDate() === 10);
+          return isLocalQSummitDate || isUtcQSummitDate;
+        }, "date must be April 9 or 10, 2026"),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const dayStart = new Date(input.date);
+      dayStart.setHours(0, 0, 0, 0);
+
+      const dayEnd = new Date(dayStart);
+      dayEnd.setDate(dayEnd.getDate() + 1);
+
+      const slotTimeFilter = and(
+        gte(shiftSlots.slotTime, dayStart),
+        lt(shiftSlots.slotTime, dayEnd),
+      );
+
+      const [totalRows, detailRows] = await Promise.all([
+        ctx.db
+          .select({
+            slotTime: shiftSlots.slotTime,
+            totalHeadcount: sql<number>`sum(${shiftSlots.headcount})`,
+          })
+          .from(shiftSlots)
+          .where(slotTimeFilter)
+          .groupBy(shiftSlots.slotTime)
+          .orderBy(asc(shiftSlots.slotTime)),
+        ctx.db
+          .select({
+            slotTime: shiftSlots.slotTime,
+            shiftId: shifts.id,
+            location: shifts.location,
+            task: shifts.task,
+            description: shifts.description,
+            notionLink: shifts.notionLink,
+            startTime: shifts.startTime,
+            endTime: shifts.endTime,
+            headcount: shiftSlots.headcount,
+          })
+          .from(shiftSlots)
+          .innerJoin(shifts, eq(shifts.id, shiftSlots.shiftId))
+          .where(slotTimeFilter)
+          .orderBy(asc(shiftSlots.slotTime), asc(shifts.startTime), asc(shifts.id)),
+      ]);
+
+      const shiftsBySlot = new Map<
+        number,
+        {
+          shiftId: string;
+          location: string;
+          task: string;
+          description: string | null;
+          notionLink: string | null;
+          startTime: Date;
+          endTime: Date;
+          headcount: number;
+        }[]
+      >();
+
+      for (const row of detailRows) {
+        const slotKey = row.slotTime.getTime();
+        const slotShifts = shiftsBySlot.get(slotKey) ?? [];
+        slotShifts.push({
+          shiftId: row.shiftId,
+          location: row.location,
+          task: row.task,
+          description: row.description,
+          notionLink: row.notionLink,
+          startTime: row.startTime,
+          endTime: row.endTime,
+          headcount: row.headcount,
+        });
+        shiftsBySlot.set(slotKey, slotShifts);
+      }
+
+      return totalRows.map((row) => ({
+        slotTime: row.slotTime,
+        totalHeadcount: Number(row.totalHeadcount ?? 0),
+        shifts: shiftsBySlot.get(row.slotTime.getTime()) ?? [],
+      }));
+    }),
+
+  exportCsv: plannerProcedure.mutation(async ({ ctx }) => {
+    // Query all shifts with their slots, skills, and tools
+    const allShifts = await ctx.db.query.shifts.findMany({
+      orderBy: [asc(shifts.startTime), asc(shifts.id)],
+    });
+
+    if (allShifts.length === 0) {
+      // UTF-8 BOM + header only
+      return {
+        csv: "\uFEFFshift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link",
+      };
+    }
+
+    const shiftIds = allShifts.map((s) => s.id);
+
+    const [allSlots, allSkills, allTools] = await Promise.all([
+      ctx.db
+        .select({
+          shiftId: shiftSlots.shiftId,
+          slotTime: shiftSlots.slotTime,
+          headcount: shiftSlots.headcount,
+        })
+        .from(shiftSlots)
+        .where(inArray(shiftSlots.shiftId, shiftIds))
+        .orderBy(asc(shiftSlots.shiftId), asc(shiftSlots.slotTime)),
+      ctx.db
+        .select({ shiftId: shiftSkills.shiftId, talentId: shiftSkills.talentId })
+        .from(shiftSkills)
+        .where(inArray(shiftSkills.shiftId, shiftIds)),
+      ctx.db
+        .select({ shiftId: shiftTools.shiftId, tool: shiftTools.tool })
+        .from(shiftTools)
+        .where(inArray(shiftTools.shiftId, shiftIds)),
+    ]);
+
+    // Aggregate skills and tools per shift
+    const skillsByShift = new Map<string, string[]>();
+    for (const skill of allSkills) {
+      const existing = skillsByShift.get(skill.shiftId) ?? [];
+      existing.push(skill.talentId);
+      skillsByShift.set(skill.shiftId, existing);
+    }
+
+    const toolsByShift = new Map<string, string[]>();
+    for (const tool of allTools) {
+      const existing = toolsByShift.get(tool.shiftId) ?? [];
+      existing.push(tool.tool);
+      toolsByShift.set(tool.shiftId, existing);
+    }
+
+    // Build CSV rows
+    const header =
+      "shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link";
+    const rows: string[] = [header];
+
+    for (const slot of allSlots) {
+      const shift = allShifts.find((s) => s.id === slot.shiftId);
+      if (!shift) continue;
+
+      const skills = (skillsByShift.get(slot.shiftId) ?? []).join(",");
+      const tools = (toolsByShift.get(slot.shiftId) ?? []).join(",");
+
+      const formatDateTime = (date: Date): string => {
+        return date
+          .toISOString()
+          .replace("T", " ")
+          .replace(/\.\d{3}Z$/, "");
+      };
+
+      // Escape semicolons in fields (shouldn't be any, but be safe)
+      const escapeField = (value: string | null): string => {
+        if (value === null) return "";
+        if (value.includes(";") || value.includes('"') || value.includes("\n")) {
+          return `"${value.replace(/"/g, '""')}"`;
+        }
+        return value;
+      };
+
+      const row = [
+        shift.id,
+        escapeField(shift.location),
+        escapeField(shift.task),
+        formatDateTime(shift.startTime),
+        formatDateTime(shift.endTime),
+        formatDateTime(slot.slotTime),
+        slot.headcount.toString(),
+        skills,
+        tools,
+        escapeField(shift.notionLink),
+      ].join(";");
+
+      rows.push(row);
+    }
+
+    // UTF-8 BOM for German Excel compatibility
+    const csv = "\uFEFF" + rows.join("\n");
+    return { csv };
+  }),
+});

--- a/src/server/api/routers/shift.ts
+++ b/src/server/api/routers/shift.ts
@@ -523,7 +523,8 @@ export const shiftRouter = createTRPCRouter({
       rows.push(row);
     }
 
-    const csv = rows.join("\n");
+    // UTF-8 BOM for German Excel compatibility
+    const csv = "\uFEFF" + rows.join("\n");
     return { csv };
   }),
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -1,9 +1,11 @@
 import { initTRPC, TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/server/db";
+import { memberProfile } from "@/server/db/schema";
 
 export const createTRPCContext = async (opts: { headers: Headers }) => {
   // Better Auth: get session from headers (cookie)
@@ -72,3 +74,39 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
 });
 
 export const protectedProcedure = t.procedure.use(loggerMiddleware).use(authMiddleware);
+
+const plannerMiddleware = t.middleware(async ({ ctx, next }) => {
+  if (!ctx?.session?.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "You must be logged in to perform this action",
+    });
+  }
+
+  const userId = ctx.session.user.id;
+
+  // Get user's profile
+  const profile = await ctx.db.query.memberProfile.findFirst({
+    where: eq(memberProfile.userId, userId),
+  });
+
+  // Chair (division = 'chair') can access - includes Chairman AND Board
+  if (profile?.division !== "chair") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only Chair/Board members can access shift planning",
+    });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      session: {
+        ...ctx.session,
+        user: ctx.session.user,
+      },
+    },
+  });
+});
+
+export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -5,7 +5,7 @@ import { ZodError } from "zod";
 
 import { auth } from "@/lib/auth";
 import { db } from "@/server/db";
-import { memberProfile } from "@/server/db/schema";
+import { memberProfile, user } from "@/server/db/schema";
 
 export const createTRPCContext = async (opts: { headers: Headers }) => {
   // Better Auth: get session from headers (cookie)
@@ -76,25 +76,29 @@ const authMiddleware = t.middleware(async ({ ctx, next }) => {
 export const protectedProcedure = t.procedure.use(loggerMiddleware).use(authMiddleware);
 
 const plannerMiddleware = t.middleware(async ({ ctx, next }) => {
-  if (!ctx?.session?.user) {
+  // Auth is guaranteed by protectedProcedure; only enforce chair/board role here.
+  if (!ctx.session?.user?.id) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
-      message: "You must be logged in to perform this action",
+      message: "Authentication required",
     });
   }
-
   const userId = ctx.session.user.id;
 
-  // Get user's profile
-  const profile = await ctx.db.query.memberProfile.findFirst({
-    where: eq(memberProfile.userId, userId),
-  });
+  const [profile, userRow] = await Promise.all([
+    ctx.db.query.memberProfile.findFirst({
+      where: eq(memberProfile.userId, userId),
+    }),
+    ctx.db.select({ isHeadOf: user.isHeadOf }).from(user).where(eq(user.id, userId)).limit(1),
+  ]);
 
-  // Chair (division = 'chair') can access - includes Chairman AND Board
-  if (profile?.division !== "chair") {
+  const isHeadOf = userRow[0]?.isHeadOf ?? false;
+  const isPlanner = profile?.division === "chair" || isHeadOf;
+
+  if (!isPlanner) {
     throw new TRPCError({
       code: "FORBIDDEN",
-      message: "Only Chair/Board members can access shift planning",
+      message: "Only Chair/Board members or heads can access shift planning",
     });
   }
 
@@ -109,4 +113,4 @@ const plannerMiddleware = t.middleware(async ({ ctx, next }) => {
   });
 });
 
-export const plannerProcedure = t.procedure.use(loggerMiddleware).use(plannerMiddleware);
+export const plannerProcedure = protectedProcedure.use(plannerMiddleware);

--- a/src/server/db/_migrations/0003_little_sandman.sql
+++ b/src/server/db/_migrations/0003_little_sandman.sql
@@ -14,7 +14,8 @@ CREATE TABLE `shift_slots` (
 	FOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);--> statement-breakpoint
+CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);
+CREATE UNIQUE INDEX `shift_slots_shiftId_slotTime_idx` ON `shift_slots` (`shiftId`, `slotTime`);--> statement-breakpoint
 CREATE TABLE `shift_tools` (
 	`id` text PRIMARY KEY NOT NULL,
 	`shiftId` text NOT NULL,

--- a/src/server/db/_migrations/0003_little_sandman.sql
+++ b/src/server/db/_migrations/0003_little_sandman.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `shift_skills` (
+	`id` text PRIMARY KEY NOT NULL,
+	`shiftId` text NOT NULL,
+	`talentId` text NOT NULL,
+	FOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`talentId`) REFERENCES `talent`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `shift_slots` (
+	`id` text PRIMARY KEY NOT NULL,
+	`shiftId` text NOT NULL,
+	`slotTime` integer NOT NULL,
+	`headcount` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `shift_slots_slot_time_idx` ON `shift_slots` (`slotTime`);--> statement-breakpoint
+CREATE TABLE `shift_tools` (
+	`id` text PRIMARY KEY NOT NULL,
+	`shiftId` text NOT NULL,
+	`tool` text NOT NULL,
+	FOREIGN KEY (`shiftId`) REFERENCES `shifts`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `shifts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`location` text NOT NULL,
+	`task` text NOT NULL,
+	`description` text,
+	`notionLink` text,
+	`startTime` integer NOT NULL,
+	`endTime` integer NOT NULL,
+	`createdBy` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`createdBy`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `shifts_start_time_idx` ON `shifts` (`startTime`);--> statement-breakpoint
+CREATE INDEX `shifts_location_idx` ON `shifts` (`location`);--> statement-breakpoint
+ALTER TABLE `user` ADD `isHeadOf` integer DEFAULT false NOT NULL;

--- a/src/server/db/_migrations/meta/0003_snapshot.json
+++ b/src/server/db/_migrations/meta/0003_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "f3c8e1b5-3c5b-4e66-9d12-3cdb8c3f7b21",
-  "prevId": "86bc391b-1451-4f7c-95fb-ec18c9d5d594",
+  "id": "642bf5b5-a8ef-4f26-b319-72ecff126788",
+  "prevId": "f3c8e1b5-3c5b-4e66-9d12-3cdb8c3f7b21",
   "tables": {
     "account": {
       "name": "account",
@@ -288,6 +288,246 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "shift_skills": {
+      "name": "shift_skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shiftId": {
+          "name": "shiftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "talentId": {
+          "name": "talentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_skills_shiftId_shifts_id_fk": {
+          "name": "shift_skills_shiftId_shifts_id_fk",
+          "tableFrom": "shift_skills",
+          "tableTo": "shifts",
+          "columnsFrom": ["shiftId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shift_skills_talentId_talent_id_fk": {
+          "name": "shift_skills_talentId_talent_id_fk",
+          "tableFrom": "shift_skills",
+          "tableTo": "talent",
+          "columnsFrom": ["talentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shift_slots": {
+      "name": "shift_slots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shiftId": {
+          "name": "shiftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slotTime": {
+          "name": "slotTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headcount": {
+          "name": "headcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "shift_slots_slot_time_idx": {
+          "name": "shift_slots_slot_time_idx",
+          "columns": ["slotTime"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shift_slots_shiftId_shifts_id_fk": {
+          "name": "shift_slots_shiftId_shifts_id_fk",
+          "tableFrom": "shift_slots",
+          "tableTo": "shifts",
+          "columnsFrom": ["shiftId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shift_tools": {
+      "name": "shift_tools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shiftId": {
+          "name": "shiftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_tools_shiftId_shifts_id_fk": {
+          "name": "shift_tools_shiftId_shifts_id_fk",
+          "tableFrom": "shift_tools",
+          "tableTo": "shifts",
+          "columnsFrom": ["shiftId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shifts": {
+      "name": "shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notionLink": {
+          "name": "notionLink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shifts_start_time_idx": {
+          "name": "shifts_start_time_idx",
+          "columns": ["startTime"],
+          "isUnique": false
+        },
+        "shifts_location_idx": {
+          "name": "shifts_location_idx",
+          "columns": ["location"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shifts_createdBy_user_id_fk": {
+          "name": "shifts_createdBy_user_id_fk",
+          "tableFrom": "shifts",
+          "tableTo": "user",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "talent": {
       "name": "talent",
       "columns": {
@@ -363,6 +603,14 @@
           "notNull": false,
           "autoincrement": false
         },
+        "isHeadOf": {
+          "name": "isHeadOf",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
         "createdAt": {
           "name": "createdAt",
           "type": "integer",
@@ -431,8 +679,8 @@
       },
       "compositePrimaryKeys": {
         "user_talent_userId_talentId_pk": {
-          "name": "user_talent_userId_talentId_pk",
-          "columns": ["userId", "talentId"]
+          "columns": ["userId", "talentId"],
+          "name": "user_talent_userId_talentId_pk"
         }
       },
       "uniqueConstraints": {},

--- a/src/server/db/_migrations/meta/_journal.json
+++ b/src/server/db/_migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772145600000,
       "tag": "0002_profile_talents",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1773436353076,
+      "tag": "0003_little_sandman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 /**
  * ──────────────────────────────────────────────────────────────────────────────
@@ -12,6 +12,7 @@ export const user = sqliteTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: integer("emailVerified", { mode: "boolean" }).notNull(),
   image: text("image"),
+  isHeadOf: integer("isHeadOf", { mode: "boolean" }).notNull().default(false),
   createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
 });
@@ -155,3 +156,57 @@ export const userTalent = sqliteTable(
     pk: primaryKey({ columns: [table.userId, table.talentId] }),
   }),
 );
+
+export const shifts = sqliteTable(
+  "shifts",
+  {
+    id: text("id").primaryKey(),
+    location: text("location").notNull(),
+    task: text("task").notNull(),
+    description: text("description"),
+    notionLink: text("notionLink"),
+    startTime: integer("startTime", { mode: "timestamp" }).notNull(),
+    endTime: integer("endTime", { mode: "timestamp" }).notNull(),
+    createdBy: text("createdBy")
+      .notNull()
+      .references(() => user.id),
+    createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  },
+  (table) => ({
+    startTimeIdx: index("shifts_start_time_idx").on(table.startTime),
+    locationIdx: index("shifts_location_idx").on(table.location),
+  }),
+);
+
+export const shiftSlots = sqliteTable(
+  "shift_slots",
+  {
+    id: text("id").primaryKey(),
+    shiftId: text("shiftId")
+      .notNull()
+      .references(() => shifts.id, { onDelete: "cascade" }),
+    slotTime: integer("slotTime", { mode: "timestamp" }).notNull(),
+    headcount: integer("headcount").notNull().default(0),
+  },
+  (table) => ({
+    slotTimeIdx: index("shift_slots_slot_time_idx").on(table.slotTime),
+  }),
+);
+
+export const shiftSkills = sqliteTable("shift_skills", {
+  id: text("id").primaryKey(),
+  shiftId: text("shiftId")
+    .notNull()
+    .references(() => shifts.id, { onDelete: "cascade" }),
+  talentId: text("talentId")
+    .notNull()
+    .references(() => talent.id, { onDelete: "cascade" }),
+});
+
+export const shiftTools = sqliteTable("shift_tools", {
+  id: text("id").primaryKey(),
+  shiftId: text("shiftId")
+    .notNull()
+    .references(() => shifts.id, { onDelete: "cascade" }),
+  tool: text("tool", { enum: ["car", "van", "equipment", "none"] }).notNull(),
+});

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,11 @@
-import { index, integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 /**
  * ──────────────────────────────────────────────────────────────────────────────
@@ -193,20 +200,29 @@ export const shiftSlots = sqliteTable(
   }),
 );
 
-export const shiftSkills = sqliteTable("shift_skills", {
-  id: text("id").primaryKey(),
-  shiftId: text("shiftId")
-    .notNull()
-    .references(() => shifts.id, { onDelete: "cascade" }),
-  talentId: text("talentId")
-    .notNull()
-    .references(() => talent.id, { onDelete: "cascade" }),
-});
+export const shiftSkills = sqliteTable(
+  "shift_skills",
+  {
+    id: text("id").primaryKey(),
+    shiftId: text("shiftId")
+      .notNull()
+      .references(() => shifts.id, { onDelete: "cascade" }),
+    talentId: text("talentId")
+      .notNull()
+      .references(() => talent.id, { onDelete: "cascade" }),
+  },
+  (table) => ({
+    shiftIdTalentIdUnique: uniqueIndex("shift_skills_shift_id_talent_id_unique").on(
+      table.shiftId,
+      table.talentId,
+    ),
+  }),
+);
 
 export const shiftTools = sqliteTable("shift_tools", {
   id: text("id").primaryKey(),
   shiftId: text("shiftId")
     .notNull()
     .references(() => shifts.id, { onDelete: "cascade" }),
-  tool: text("tool", { enum: ["car", "van", "equipment", "none"] }).notNull(),
+  tool: text("tool", { enum: ["car", "van", "equipment"] }).notNull(),
 });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -176,7 +176,7 @@ export const shifts = sqliteTable(
     endTime: integer("endTime", { mode: "timestamp" }).notNull(),
     createdBy: text("createdBy")
       .notNull()
-      .references(() => user.id),
+      .references(() => user.id, { onDelete: "cascade" }),
     createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
   },
   (table) => ({

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -176,7 +176,7 @@ export const shifts = sqliteTable(
     endTime: integer("endTime", { mode: "timestamp" }).notNull(),
     createdBy: text("createdBy")
       .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => user.id),
     createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
   },
   (table) => ({

--- a/src/trpc/msw.tsx
+++ b/src/trpc/msw.tsx
@@ -10,14 +10,6 @@ import { api } from "@/server/api/client";
 import type { AppRouter } from "@/server/api/root";
 
 /**
- * Get the tRPC API URL for Storybook.
- * Uses relative path so MSW can intercept requests.
- */
-function getUrl() {
-  return "/api/trpc";
-}
-
-/**
  * Typed MSW handlers for tRPC endpoints.
  *
  * Use this with msw-trpc to create type-safe mock handlers in Storybook stories.
@@ -28,8 +20,11 @@ function getUrl() {
  * ```
  */
 export const trpcMsw = createTRPCMsw<AppRouter>({
-  baseUrl: getUrl(),
-  transformer: { input: superjson, output: superjson },
+  baseUrl: "/api/trpc",
+  transformer: {
+    input: superjson,
+    output: superjson,
+  },
 });
 
 /**
@@ -59,7 +54,7 @@ export function TRPCReactProviderStorybook(props: { children: React.ReactNode })
     api.createClient({
       links: [
         httpLink({
-          url: getUrl(),
+          url: "/api/trpc",
           transformer: superjson,
           headers() {
             return {


### PR DESCRIPTION
## Summary

Implements a comprehensive shift planning system for coordinating Q-Summit 2026 volunteer assignments. This feature enables Chair and Board members to create, manage, and export shift schedules.

## What's New

### 🗄️ Database Schema
- **New tables:** `shifts`, `shift_slots`, `shift_skills`, `shift_tools`
- **User enhancement:** Added `isHeadOf` flag for role-based access control
- **Performance:** Indexed queries on `startTime` and `location`

### 🔌 API (tRPC)
- Full CRUD operations for shift management
- CSV export endpoint for external tools (Excel/Google Sheets)
- Role-based access control — restricted to planners only

### 🎨 UI Components
| Component | Purpose |
|-----------|---------|
| `ShiftManager` | Main container with calendar/list view switching |
| `ShiftForm` | Create/edit shifts with validation |
| `ShiftList` | Browse and filter all shifts |
| `CalendarView` | Visual calendar for event days (Apr 9-10, 2026) |
| `CsvExportButton` | One-click export to CSV |

### 📚 Documentation
Complete docs in `.docs/shifts/`:
- [README](.docs/shifts/README.md) — Overview and data model
- [Workflow](.docs/shifts/workflow.md) — How to create/manage shifts
- [CSV Format](.docs/shifts/csv-format.md) — Export specification
- [Role Access](.docs/shifts/role-access.md) — Who can access what
- [API Reference](.docs/shifts/api-reference.md) — Technical endpoints

### 🧪 Testing
- Storybook stories for all UI components
- MSW handlers for API mocking in stories

## Data Model

A **Shift** consists of:
- **Basic Info:** Location, task, description, optional Notion link
- **Time Schedule:** Start/end times with 30-min slot granularity
- **Requirements:** Required skills (talents) and tools/equipment
- **Headcount:** Volunteers needed per time slot

```
Shift → has many → ShiftSlots (time slots with headcount)
Shift → requires → ShiftSkills (talents needed)
Shift → requires → ShiftTools (equipment needed)
```

## Access Control

| Role | Access |
|------|--------|
| Chair/Board (isHeadOf=true) | Full access — create, edit, export |
| Regular users | No access — shifts page is restricted |

## Export Format

CSV exports include all shift data for external coordination:
```csv
shift_id;location;task;start_time;end_time;slot_time;headcount;skills;tools;notion_link
```

## Migration Required

⚠️ **Database migration needed:** Run `bun run db:push` after deploy

## Related

Closes #9

## Screenshots / Testing

Test via Storybook:
```bash
bun run storybook
# Navigate to: Shifts/ShiftManager
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full volunteer shift planning system for Q‑Summit 2026 with CRUD, calendar/list views, and Excel‑ready CSV export; `/shifts` is gated to planners (Chair or `user.isHeadOf`) and renders `ShiftManager`. Closes #9.

- **New Features**
  - Database: `shifts`, `shift_slots`, `shift_skills`, `shift_tools`; adds `user.isHeadOf`; indexes on `shifts.startTime`, `shifts.location`, and unique `shift_slots(shiftId, slotTime)`; `createdBy` does not cascade on delete (shifts are preserved).
  - API: `shift` router via `@trpc/server` + `drizzle-orm` with CRUD, list/calendar, and CSV export (semicolon + UTF‑8 BOM); `plannerProcedure` builds on `protectedProcedure` and enforces planner role (Chair or `isHeadOf`); list/calendar are auth‑only; export is planner‑only.
  - UI: `ShiftManager`, `ShiftForm`, `ShiftList`, `CalendarView`, `CsvExportButton`; `/shifts` page enforces planner access; improved a11y (keyboard support, labelled controls, and an aria‑label on the Create button).
  - Validation/UX: accepts blank Notion links; fixes UTC day windows and related filtering; docs and Storybook updated.

- **Migration**
  - Run: `bun run db:push` to add new tables, `isHeadOf`, indexes (incl. unique `shift_slots(shiftId, slotTime)`), and FK updates.

<sup>Written for commit a4fddf2999afaf0d7bb6e2a5786aa67a3831baff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

